### PR TITLE
Redesign mobile service-timeline cards + browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '21'
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Make Gradle Wrapper Executable # Runs chmod to make gradlew executable on Ubuntu runner
         run: chmod +x ./gradlew  
       - name: Build with Gradle
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '21'
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Make Gradle Wrapper Executable
         run: chmod +x ./gradlew
       - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,20 @@ repositories {
 	mavenCentral()
 }
 
+// Browser tests live in src/browserTest. Separate source set so the
+// slow Playwright suite doesn't bog down `./gradlew test`.
+sourceSets {
+    browserTest {
+        compileClasspath += sourceSets.main.output + sourceSets.test.output
+        runtimeClasspath += sourceSets.main.output + sourceSets.test.output
+    }
+}
+
+configurations {
+    browserTestImplementation.extendsFrom testImplementation
+    browserTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -32,11 +46,28 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.mockito:mockito-core:5.11.0'
+
+    // Playwright drives a real Chromium for full-stack browser tests.
+    // First run downloads ~150MB of browser binaries to ~/.cache/ms-playwright/.
+    browserTestImplementation 'com.microsoft.playwright:playwright:1.47.0'
 }
 
 test {
     useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
+    }
+}
+
+tasks.register('browserTest', Test) {
+    description = 'Runs Playwright browser tests (full-stack via real Chromium). Slow — opt-in.'
+    group = 'verification'
+    testClassesDirs = sourceSets.browserTest.output.classesDirs
+    classpath = sourceSets.browserTest.runtimeClasspath
+    useJUnitPlatform()
+    shouldRunAfter test
+    testLogging {
+        events "passed", "skipped", "failed"
+        showStandardStreams = true
     }
 }

--- a/src/browserTest/java/com/example/AviaryService/browser/BrowserTestBase.java
+++ b/src/browserTest/java/com/example/AviaryService/browser/BrowserTestBase.java
@@ -1,0 +1,94 @@
+package com.example.AviaryService.browser;
+
+import com.example.AviaryService.entity.User;
+import com.example.AviaryService.repositories.UserRepository;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("browsertest")
+public abstract class BrowserTestBase {
+
+    // Shared across the whole test class — launching Chromium is the most
+    // expensive step in a Playwright run, so we keep one Browser per JVM
+    // and isolate state with fresh BrowserContexts per test.
+    private static Playwright playwright;
+    private static Browser browser;
+
+    protected BrowserContext context;
+    protected Page page;
+
+    @LocalServerPort
+    protected int port;
+
+    @Autowired
+    protected UserRepository userRepository;
+
+    @Autowired
+    protected PasswordEncoder passwordEncoder;
+
+    private static final AtomicInteger USER_COUNTER = new AtomicInteger();
+
+    @BeforeAll
+    static void launchBrowser() {
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch(
+                new BrowserType.LaunchOptions().setHeadless(true));
+    }
+
+    @AfterAll
+    static void shutdownBrowser() {
+        if (browser != null) browser.close();
+        if (playwright != null) playwright.close();
+    }
+
+    @BeforeEach
+    void openPage() {
+        context = browser.newContext();
+        page = context.newPage();
+    }
+
+    @AfterEach
+    void closePage() {
+        if (context != null) context.close();
+    }
+
+    protected String baseUrl() {
+        return "http://localhost:" + port;
+    }
+
+    /** Create a user directly in the DB with a known password. Returns the username. */
+    protected String seedUser(String rawPassword) {
+        String username = "browser_user_" + USER_COUNTER.incrementAndGet();
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(passwordEncoder.encode(rawPassword));
+        userRepository.save(user);
+        return username;
+    }
+
+    /** Drive the real /login form. Asserts redirect to /dashboard succeeded. */
+    protected void loginAs(String username, String rawPassword) {
+        page.navigate(baseUrl() + "/login");
+        page.fill("input[name='username']", username);
+        page.fill("input[name='password']", rawPassword);
+        // Login form has two type=submit buttons (real + Google placeholder).
+        // The first is the real login button.
+        page.locator("button.login-button").click();
+        page.waitForURL(baseUrl() + "/dashboard");
+    }
+}

--- a/src/browserTest/java/com/example/AviaryService/browser/DashboardLayoutTest.java
+++ b/src/browserTest/java/com/example/AviaryService/browser/DashboardLayoutTest.java
@@ -1,0 +1,454 @@
+package com.example.AviaryService.browser;
+
+import com.example.AviaryService.entity.ServiceTimeline;
+import com.example.AviaryService.entity.User;
+import com.example.AviaryService.repositories.ServiceTimelineRepository;
+import com.example.AviaryService.repositories.UserRepository;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.LoadState;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Regression tests for the dashboard's table layout. Covers:
+ *  - The Add submit button is exactly the size of its parent <form>
+ *    (the "button overlapping form" bug).
+ *  - The Item textarea starts at one-line height for short content
+ *    (the "unnecessarily big" bug).
+ *  - Column proportions match the post-fix spec.
+ *
+ * The first test also writes a screenshot of the populated dashboard so
+ * a human can sanity-check layout in the build report.
+ */
+class DashboardLayoutTest extends BrowserTestBase {
+
+    @Autowired
+    UserRepository users;
+
+    @Autowired
+    ServiceTimelineRepository timelines;
+
+    private List<String> attachConsoleErrorListener() {
+        List<String> errors = new ArrayList<>();
+        page.onConsoleMessage(msg -> {
+            if ("error".equals(msg.type())) errors.add(msg.text());
+        });
+        return errors;
+    }
+
+    private void seedThreeRows(User user) {
+        for (int i = 1; i <= 3; i++) {
+            ServiceTimeline t = new ServiceTimeline();
+            t.setUser(user);
+            t.setItem("Row " + i);
+            t.setIsTitle(false);
+            t.setTimelineOrder(i);
+            t.setDescription("Inspect");
+            t.setLastDone("2025-10-01");
+            t.setDueDate("2026-12-01");
+            t.setTimeLeft("");
+            timelines.save(t);
+        }
+    }
+
+    /** Read a getBoundingClientRect property (width, height, x, y...) as px. */
+    private double pxOf(com.microsoft.playwright.Locator loc, String prop) {
+        Object v = loc.evaluate("(el, prop) => el.getBoundingClientRect()[prop]", prop);
+        return ((Number) v).doubleValue();
+    }
+
+    @Test
+    void addButtonExactlyFillsItsParentForm() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        seedThreeRows(u);
+
+        var errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var form = page.locator("td.add-cell form");
+        var button = page.locator("td.add-cell form button.add-button");
+
+        double formW   = pxOf(form, "width");
+        double formH   = pxOf(form, "height");
+        double btnW    = pxOf(button, "width");
+        double btnH    = pxOf(button, "height");
+
+        // Button must match form dimensions within sub-pixel tolerance.
+        if (Math.abs(formW - btnW) > 0.5) {
+            throw new AssertionError("Add button width " + btnW + "px does not match form width " + formW + "px");
+        }
+        if (Math.abs(formH - btnH) > 0.5) {
+            throw new AssertionError("Add button height " + btnH + "px does not match form height " + formH + "px");
+        }
+
+        // Save a screenshot for human-eyeball verification.
+        Path screenshot = Paths.get("build", "reports", "browserTest-screenshots", "dashboard-after-fix.png");
+        screenshot.toFile().getParentFile().mkdirs();
+        page.screenshot(new Page.ScreenshotOptions()
+                .setPath(screenshot)
+                .setFullPage(true));
+
+        if (!errors.isEmpty()) throw new AssertionError("Console errors: " + errors);
+    }
+
+    @Test
+    void shortItemTextareaStartsAtAboutOneLineHeight() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        ServiceTimeline t = new ServiceTimeline();
+        t.setUser(u);
+        t.setItem("Oil");           // single short token — should fit one line
+        t.setIsTitle(false);
+        t.setTimelineOrder(1);
+        timelines.save(t);
+
+        var errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var textarea = page.locator(
+                "tr.auto-save-row[data-id='" + t.getId() + "'] textarea[name='item']");
+        double h = pxOf(textarea, "height");
+
+        // One 13px-line + ~8px padding ≈ 22-32px. Anything above ~40px is
+        // the "unnecessarily big" regression we're guarding against.
+        if (h > 40.0) {
+            throw new AssertionError(
+                    "Item textarea is " + h + "px tall for short text — expected ≤40px");
+        }
+
+        if (!errors.isEmpty()) throw new AssertionError("Console errors: " + errors);
+    }
+
+    @Test
+    void itemColumnMatchesDescriptionAndDateColumnsAreWider() {
+        // Column proportions spec: Item (18%) should be about the same width as
+        // Description (18%) — the free-text Item column must NOT dominate — and
+        // the date columns (Last Done / Due Date, 20%) should be at least as
+        // wide as Item so their calendar + hours inputs have room.
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        seedThreeRows(u);
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+        page.setViewportSize(1400, 900);
+
+        // Sortable head th's: 1=grip 2=Item 3=Description 4=Cycle 5=Last Done
+        //                     6=Due Date 7=Time Left 8=Complete 9=Delete
+        var ths = page.locator("thead.sortable-head th");
+        double itemW        = pxOf(ths.nth(1), "width");
+        double descriptionW = pxOf(ths.nth(2), "width");
+        double cycleW       = pxOf(ths.nth(3), "width");
+        double lastDoneW    = pxOf(ths.nth(4), "width");
+        double dueDateW     = pxOf(ths.nth(5), "width");
+        double deleteW      = pxOf(ths.nth(8), "width");
+
+        // Item ≈ Description (same percentage). Allow a small tolerance for
+        // borders/rounding.
+        if (Math.abs(itemW - descriptionW) > 8.0) {
+            throw new AssertionError("Item col (" + itemW + ") should be about the same width as Description ("
+                    + descriptionW + ")");
+        }
+        // Date columns must be at least as wide as Item (they're 20% vs 18%).
+        if (!(lastDoneW >= itemW - 1)) {
+            throw new AssertionError("Last Done col (" + lastDoneW + ") should be >= Item (" + itemW + ")");
+        }
+        if (!(dueDateW >= itemW - 1)) {
+            throw new AssertionError("Due Date col (" + dueDateW + ") should be >= Item (" + itemW + ")");
+        }
+        // Cycle is allowed to be wide because it hosts a two-row input group.
+        if (cycleW < 60) {
+            throw new AssertionError("Cycle col (" + cycleW + "px) too narrow for its inputs");
+        }
+        // Delete column is 4% (with 36px floor). On normal viewports it should
+        // be much smaller than Item — guard against percentage flips.
+        if (deleteW >= itemW / 2) {
+            throw new AssertionError("Delete col (" + deleteW + ") should be much smaller than Item (" + itemW + ")");
+        }
+        if (deleteW < 36) {
+            throw new AssertionError("Delete col (" + deleteW + "px) below 36px floor");
+        }
+    }
+
+    @Test
+    void dateInputsStayInsideTheirCellsWhenWindowIsNarrow() {
+        // Regression: when the window narrowed, the calendar (mm/dd/yyyy) and
+        // hours inputs in Last Done / Due Date used to collapse and spill out
+        // of their cell, hiding behind neighbouring columns. min-width floors
+        // on the inputs + columns must keep each field fully inside its own td.
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+
+        ServiceTimeline t = new ServiceTimeline();
+        t.setUser(u);
+        t.setItem("Magneto");
+        t.setIsTitle(false);
+        t.setTimelineOrder(1);
+        t.setDescription("Inspect");
+        // Both a date and an hours value so each cell renders both inputs.
+        t.setLastDone("2025-10-01 100.5");
+        t.setDueDate("2026-12-01 250");
+        t.setTimeLeft("");
+        timelines.save(t);
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // Narrow, but still above the 960px card breakpoint (desktop table).
+        page.setViewportSize(1000, 800);
+
+        // td:nth-child(5) = Last Done, td:nth-child(6) = Due Date.
+        int[] tdIndexes = { 5, 6 };
+        for (int td : tdIndexes) {
+            var cell = page.locator(
+                    "tr.auto-save-row[data-id='" + t.getId() + "'] td:nth-child(" + td + ")");
+            double[] cellRect = rectOf(cell);
+
+            for (String type : new String[] { "input[type='date']", "input[type='text'].extra-input" }) {
+                var input = cell.locator(type);
+                double[] r = rectOf(input);
+                // Fully inside the cell horizontally (allow ~1px AA slack).
+                if (r[0] < cellRect[0] - 1.0) {
+                    throw new AssertionError("td " + td + " " + type + " left edge " + r[0]
+                            + " spills left of cell " + cellRect[0]);
+                }
+                if (r[0] + r[2] > cellRect[0] + cellRect[2] + 1.0) {
+                    throw new AssertionError("td " + td + " " + type + " right edge " + (r[0] + r[2])
+                            + " spills past cell right " + (cellRect[0] + cellRect[2]));
+                }
+                // And actually has a usable width.
+                if (r[2] < 60.0) {
+                    throw new AssertionError("td " + td + " " + type + " too narrow (" + r[2] + "px) — would hide content");
+                }
+            }
+        }
+    }
+
+    /** Read getBoundingClientRect into [x, y, w, h]. */
+    private double[] rectOf(com.microsoft.playwright.Locator loc) {
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> r = (java.util.Map<String, Object>) loc.evaluate(
+                "el => { const r = el.getBoundingClientRect();"
+                + " return { x: r.x, y: r.y, w: r.width, h: r.height }; }");
+        return new double[] {
+                ((Number) r.get("x")).doubleValue(),
+                ((Number) r.get("y")).doubleValue(),
+                ((Number) r.get("w")).doubleValue(),
+                ((Number) r.get("h")).doubleValue()
+        };
+    }
+
+    @Test
+    void iconsInGripCompleteAndDeleteCellsAreVerticallyCentered() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        // Seed a row whose Cycle inputs (two-row) push the row taller than
+        // a single icon — that's the regression case where top-aligned icons
+        // looked stuck to the top.
+        seedThreeRows(u);
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var row = page.locator("tr.auto-save-row").first();
+        // Compare each icon's vertical center against the row's vertical
+        // center; allow ±4px slack for borders/padding rounding.
+        double[] rowRect    = rectOf(row);
+        double rowMid       = rowRect[1] + rowRect[3] / 2.0;
+
+        java.util.Map<String, com.microsoft.playwright.Locator> icons = new java.util.LinkedHashMap<>();
+        icons.put("grip",     row.locator(".grip-icon"));
+        icons.put("complete", row.locator(".complete-btn"));
+        icons.put("delete",   row.locator(".delete-icon"));
+
+        for (var entry : icons.entrySet()) {
+            double[] r = rectOf(entry.getValue());
+            double iconMid = r[1] + r[3] / 2.0;
+            if (Math.abs(iconMid - rowMid) > 4.0) {
+                throw new AssertionError(entry.getKey() + " icon mid " + iconMid
+                        + " differs from row mid " + rowMid + " by more than 4px");
+            }
+        }
+    }
+
+    @Test
+    void addRowDescriptionChevronSitsInsideTheBorderedWrapper() {
+        // Add-row's description dropdown should mirror the Last Done / Due
+        // Date pattern: chevron INSIDE the bordered box, not floating
+        // outside. We assert the chevron's bounding rect is fully contained
+        // by the .custom-dropdown's bounding rect.
+        String username = seedUser("password");
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var wrapper = page.locator(".add-row .custom-dropdown").first();
+        var chevron = wrapper.locator(".trigger-dropdown");
+
+        double[] w = rectOf(wrapper);
+        double[] c = rectOf(chevron);
+
+        // chevron x and y must be inside wrapper; right/bottom edges too.
+        if (!(c[0] >= w[0] - 0.5 && c[1] >= w[1] - 0.5
+                && c[0] + c[2] <= w[0] + w[2] + 0.5
+                && c[1] + c[3] <= w[1] + w[3] + 0.5)) {
+            throw new AssertionError("Chevron rect " + java.util.Arrays.toString(c)
+                    + " is not contained by wrapper rect " + java.util.Arrays.toString(w));
+        }
+    }
+
+    @Test
+    void timeLeftColumnIsSizedToContentNotAFatFixedWidth() {
+        // Regression: Time Left used to be a fixed 16% of the table, leaving it
+        // far wider than its content and starving the other columns. After the
+        // switch to table-layout:auto with no width hint on Time Left, the
+        // column should size to its content (the "TIME LEFT" header or the
+        // widest data line) — clearly narrower than Item/Description and well
+        // below the old ~16% slab.
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+
+        // A long-overdue calendar date yields a wide value like
+        // "9600 days overdue" — the widest realistic Time Left content.
+        ServiceTimeline t = new ServiceTimeline();
+        t.setUser(u);
+        t.setItem("Engine");
+        t.setIsTitle(false);
+        t.setTimelineOrder(1);
+        t.setDescription("Inspect");
+        t.setLastDone("2000-01-01");
+        t.setDueDate("2000-01-01");
+        t.setTimeLeft("");
+        timelines.save(t);
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // Wide viewport makes the distinction unambiguous: at 1600px the old
+        // 16% column would be ~250px, while content sizing keeps it <200px.
+        page.setViewportSize(1600, 900);
+
+        // The JS-computed Time Left must actually be populated and wide.
+        var timeLeftCell = page.locator(
+                "tr.auto-save-row[data-id='" + t.getId() + "'] .time-left");
+        String tlText = timeLeftCell.textContent().trim();
+        if (!tlText.contains("overdue")) {
+            throw new AssertionError("Expected an 'overdue' Time Left value, got: '" + tlText + "'");
+        }
+
+        var ths = page.locator("thead.sortable-head th");
+        double itemW        = pxOf(ths.nth(1), "width");
+        double descriptionW = pxOf(ths.nth(2), "width");
+        double timeLeftW     = pxOf(ths.nth(6), "width");
+
+        if (!(timeLeftW < itemW)) {
+            throw new AssertionError("Time Left col (" + timeLeftW + ") should be narrower than Item (" + itemW + ")");
+        }
+        if (!(timeLeftW < descriptionW)) {
+            throw new AssertionError("Time Left col (" + timeLeftW + ") should be narrower than Description (" + descriptionW + ")");
+        }
+        // Content-sized, not the old fat ~16% slab (~250px @1600w).
+        if (timeLeftW >= 200) {
+            throw new AssertionError("Time Left col (" + timeLeftW + "px) is too wide — expected content-sized (<200px)");
+        }
+        // Floor: must still fit the "TIME LEFT" header on one line.
+        if (timeLeftW < 60) {
+            throw new AssertionError("Time Left col (" + timeLeftW + "px) is below the header floor");
+        }
+    }
+
+    @Test
+    void calendarAlwaysStacksAboveHoursRegardlessOfAddOrder() {
+        // The Last Done / Due Date cells let the user add a Calendar (date) and
+        // a Clock (hours) input via a +/- menu. Requirement: the inputs always
+        // stack vertically with Calendar on TOP and Hours on the BOTTOM, no
+        // matter which was added first; removing Calendar moves Hours back up.
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+
+        // Empty Last Done / Due Date so the row starts with no inputs — just
+        // the chevron — and we drive the +/- menu ourselves.
+        ServiceTimeline t = new ServiceTimeline();
+        t.setUser(u);
+        t.setItem("Battery");
+        t.setIsTitle(false);
+        t.setTimelineOrder(1);
+        t.setDescription("Inspect");
+        t.setLastDone("");
+        t.setDueDate("");
+        t.setTimeLeft("");
+        timelines.save(t);
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var cell = page.locator(
+                "tr.auto-save-row[data-id='" + t.getId() + "'] td:nth-child(5) .input-with-dropdown");
+
+        // Add CLOCK first (the harder case — added first but must end on bottom).
+        cell.locator(".trigger-dropdown").click();
+        cell.locator(".add-type[data-type='clock']").click();
+        // Then add CALENDAR second — it must jump above the hours input.
+        cell.locator(".trigger-dropdown").click();
+        cell.locator(".add-type[data-type='calendar']").click();
+
+        var dateInput  = cell.locator("input[type='date'].extra-input");
+        var hoursInput = cell.locator("input[type='text'].extra-input");
+
+        double[] dateRect  = rectOf(dateInput);
+        double[] hoursRect = rectOf(hoursInput);
+
+        // Stacked vertically: same left edge (within tolerance), calendar above.
+        if (Math.abs(dateRect[0] - hoursRect[0]) > 2.0) {
+            throw new AssertionError("Inputs not vertically stacked — date x=" + dateRect[0]
+                    + ", hours x=" + hoursRect[0]);
+        }
+        if (!(dateRect[1] < hoursRect[1])) {
+            throw new AssertionError("Calendar (y=" + dateRect[1] + ") should sit ABOVE hours (y="
+                    + hoursRect[1] + ") even though hours was added first");
+        }
+
+        // Remove CALENDAR — hours must move up into the top slot.
+        cell.locator(".trigger-dropdown").click();
+        cell.locator(".add-type[data-type='calendar']").click();
+
+        if (dateInput.count() != 0) {
+            throw new AssertionError("Calendar input should be gone after removal");
+        }
+        double hoursYAfter = rectOf(hoursInput)[1];
+        if (!(hoursYAfter < hoursRect[1] + 0.5)) {
+            throw new AssertionError("Hours should move up after calendar removed — was y="
+                    + hoursRect[1] + ", now y=" + hoursYAfter);
+        }
+    }
+
+    @Test
+    void addButtonScalesWithScreenWidth() {
+        // The icon columns are 4% each → on wider viewports the add-cell
+        // (colspan=2) gets wider. Verify by measuring at two viewport sizes.
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        seedThreeRows(u);
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        page.setViewportSize(1000, 800);
+        double narrowBtn = pxOf(page.locator("td.add-cell button.add-button"), "width");
+
+        page.setViewportSize(1600, 800);
+        double wideBtn = pxOf(page.locator("td.add-cell button.add-button"), "width");
+
+        if (!(wideBtn > narrowBtn)) {
+            throw new AssertionError("Add button should grow with screen width — "
+                    + "got " + narrowBtn + "px @1000w and " + wideBtn + "px @1600w");
+        }
+    }
+}

--- a/src/browserTest/java/com/example/AviaryService/browser/DashboardMobileCardsTest.java
+++ b/src/browserTest/java/com/example/AviaryService/browser/DashboardMobileCardsTest.java
@@ -1,0 +1,179 @@
+package com.example.AviaryService.browser;
+
+import com.example.AviaryService.entity.FlightLog;
+import com.example.AviaryService.entity.ServiceTimeline;
+import com.example.AviaryService.entity.User;
+import com.example.AviaryService.repositories.FlightLogRepository;
+import com.example.AviaryService.repositories.ServiceTimelineRepository;
+import com.example.AviaryService.repositories.UserRepository;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.LoadState;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the mobile cards.
+ *
+ * At phone width (<=768px) each Service Timeline row and each Log Book row
+ * collapses into a card. The current design requires, on a 390px viewport:
+ *  - the card lays out as a CSS grid (not the old space-between flex rows),
+ *  - the Item is a bold headline (font-weight 700),
+ *  - the display fields are FLAT and BORDERLESS (no rounded "bubble" boxes) so
+ *    they match the desktop cells,
+ *  - Time Left is a plain readout (no green pill background),
+ *  - the Complete action is a full-width button,
+ *  - Log Book rows also lay out as a 2-column grid.
+ *
+ * The first test writes a full-page screenshot so a human can eyeball the
+ * cards in the build report.
+ */
+class DashboardMobileCardsTest extends BrowserTestBase {
+
+    private static final int PHONE_W = 390;
+    private static final int PHONE_H = 844;
+
+    @Autowired
+    UserRepository users;
+
+    @Autowired
+    ServiceTimelineRepository timelines;
+
+    @Autowired
+    FlightLogRepository flightLogs;
+
+    private void seedData(User user) {
+        ServiceTimeline title = new ServiceTimeline();
+        title.setUser(user);
+        title.setItem("ENGINE");
+        title.setIsTitle(true);
+        title.setTimelineOrder(0);
+        timelines.save(title);
+
+        ServiceTimeline item = new ServiceTimeline();
+        item.setUser(user);
+        item.setItem("Annual Inspection");
+        item.setIsTitle(false);
+        item.setTimelineOrder(1);
+        item.setDescription("Inspect");
+        item.setCycleCalendarValue(12);
+        item.setCycleCalendarUnit("MONTHS");
+        item.setCycleHours(100.0);
+        item.setLastDone("2025-06-01");
+        item.setDueDate("2026-06-01 2450.0");
+        item.setTimeLeft("11 mo\n86.0 hrs");
+        timelines.save(item);
+
+        FlightLog log = new FlightLog();
+        log.setUser(user);
+        log.setFromAirport("KSQL");
+        log.setToAirport("KPAO");
+        log.setHobbsOut(1234.5);
+        log.setHobbsIn(1236.1);
+        log.setTachOut(1100.2);
+        log.setTachIn(1101.5);
+        flightLogs.save(log);
+    }
+
+    private double pxOf(Locator loc, String prop) {
+        Object v = loc.evaluate("(el, prop) => el.getBoundingClientRect()[prop]", prop);
+        return ((Number) v).doubleValue();
+    }
+
+    private String cssOf(Locator loc, String prop) {
+        return (String) loc.evaluate("(el, p) => getComputedStyle(el).getPropertyValue(p)", prop);
+    }
+
+    private void openDashboardOnPhone() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        seedData(u);
+        page.setViewportSize(PHONE_W, PHONE_H);
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+        // Last Done / Due Date inputs are injected by JS from the row's
+        // data-* attributes on load — wait for one before measuring.
+        page.locator("tr.auto-save-row td[data-label='Due Date'] input.extra-input")
+                .first().waitFor();
+    }
+
+    @Test
+    void serviceTimelineCardUsesFlatBorderlessFields() {
+        openDashboardOnPhone();
+
+        Locator row = page.locator("tr.auto-save-row").first();
+        assertEquals("grid", cssOf(row, "display"),
+                "Saved service-timeline card should lay out as a CSS grid on mobile");
+
+        // Item is a bold headline.
+        Locator itemText = row.locator("td[data-label='Item'] textarea");
+        assertEquals("700", cssOf(itemText, "font-weight"),
+                "Item should render as a bold headline (font-weight 700)");
+
+        // Display fields are FLAT and BORDERLESS (no rounded "bubble"), matching
+        // the desktop cells.
+        assertEquals("none",
+                cssOf(row.locator("td[data-label='Description'] .custom-dropdown"), "border-top-style"),
+                "Description should be borderless on mobile (no bubble)");
+        assertEquals("none",
+                cssOf(row.locator("td[data-label='Cycle'] .cycle-structured"), "border-top-style"),
+                "Cycle should be borderless on mobile (no bubble)");
+        assertEquals("none",
+                cssOf(row.locator("td[data-label='Due Date'] .input-with-dropdown"), "border-top-style"),
+                "Due Date wrapper should be borderless on mobile (no bubble)");
+
+        // Time Left is a plain readout — no green pill background.
+        assertEquals("rgba(0, 0, 0, 0)",
+                cssOf(row.locator(".time-left"), "background-color"),
+                "Time Left should be a plain readout (transparent), not a pill");
+
+        // The Complete action stays a comfortable full-width button.
+        double completeH = pxOf(row.locator(".complete-btn"), "height");
+        assertTrue(completeH >= 44, "Complete button should be >=44px tall, was " + completeH);
+        double rowW = pxOf(row, "width");
+        double completeW = pxOf(row.locator(".complete-btn"), "width");
+        // grid padding is 14px each side; allow generous tolerance.
+        assertTrue(completeW >= rowW - 60,
+                "Complete button should span the card width (card " + rowW + ", btn " + completeW + ")");
+
+        Path shot = Paths.get("build", "browsertest-screenshots", "mobile-cards-flat.png");
+        try {
+            Files.createDirectories(shot.getParent());
+        } catch (Exception ignored) { }
+        page.screenshot(new Page.ScreenshotOptions().setPath(shot).setFullPage(true));
+    }
+
+    @Test
+    void logBookCardUsesTwoColumnGrid() {
+        openDashboardOnPhone();
+
+        // Switch to the Log Book tab and wait for it to become visible.
+        page.locator("button.tab-button[data-tab='logbook-tab']").click();
+        Locator logRow = page.locator("tr.log-row").first();
+        logRow.waitFor();
+
+        assertEquals("grid", cssOf(logRow, "display"),
+                "Log Book card should lay out as a CSS grid on mobile");
+
+        // Computed grid-template-columns is two pixel tracks, e.g. "171px 171px".
+        String cols = cssOf(logRow, "grid-template-columns").trim();
+        assertEquals(2, cols.split("\\s+").length,
+                "Log Book card should have two columns, was: " + cols);
+
+        double inputH = pxOf(logRow.locator("input[name='fromAirport']"), "height");
+        assertTrue(inputH >= 44, "Log Book input should be >=44px tall, was " + inputH);
+
+        Path shot = Paths.get("build", "browsertest-screenshots", "mobile-logbook-optionC.png");
+        try {
+            Files.createDirectories(shot.getParent());
+        } catch (Exception ignored) { }
+        page.screenshot(new Page.ScreenshotOptions().setPath(shot).setFullPage(true));
+    }
+}

--- a/src/browserTest/java/com/example/AviaryService/browser/FlightLogTableEdgeCasesTest.java
+++ b/src/browserTest/java/com/example/AviaryService/browser/FlightLogTableEdgeCasesTest.java
@@ -1,0 +1,211 @@
+package com.example.AviaryService.browser;
+
+import com.example.AviaryService.entity.FlightLog;
+import com.example.AviaryService.entity.User;
+import com.example.AviaryService.repositories.FlightLogRepository;
+import com.example.AviaryService.repositories.UserRepository;
+import com.microsoft.playwright.options.LoadState;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+/**
+ * Edge-case rendering tests for the Flight Log table on the dashboard.
+ *
+ * Flight Log rows render with both a print-only span (for the print
+ * stylesheet) and a readonly input (visible on screen). The input is
+ * what users see, so most assertions go against input.value.
+ *
+ * Add a test here every time the Flight Log UI is fixed or extended.
+ */
+class FlightLogTableEdgeCasesTest extends BrowserTestBase {
+
+    @Autowired
+    UserRepository users;
+
+    @Autowired
+    FlightLogRepository flightLogs;
+
+    private List<String> attachConsoleErrorListener() {
+        List<String> errors = new ArrayList<>();
+        page.onConsoleMessage(msg -> {
+            if ("error".equals(msg.type())) errors.add(msg.text());
+        });
+        return errors;
+    }
+
+    private void assertNoConsoleErrors(List<String> errors) {
+        if (!errors.isEmpty()) throw new AssertionError("Console errors: " + errors);
+    }
+
+    private FlightLog saveLog(User user, String from, String to,
+                              Double hobbsOut, Double hobbsIn,
+                              Double tachOut, Double tachIn) {
+        FlightLog log = new FlightLog();
+        log.setUser(user);
+        log.setFromAirport(from);
+        log.setToAirport(to);
+        log.setHobbsOut(hobbsOut);
+        log.setHobbsIn(hobbsIn);
+        log.setTachOut(tachOut);
+        log.setTachIn(tachIn);
+        return flightLogs.save(log);
+    }
+
+    @Test
+    void emptyLogbookRendersNoLogRows() {
+        String username = seedUser("password");
+        List<String> errors = attachConsoleErrorListener();
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // Only the add-log-row is in the tbody for a user with no logs.
+        assertThat(page.locator("tbody#logbook-body tr.log-row")).hasCount(0);
+        assertThat(page.locator("tbody#logbook-body tr.add-log-row")).hasCount(1);
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void typicalLogRendersAllCellsWithDecimalHours() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        FlightLog log = saveLog(u, "KAAA", "KBBB", 100.0, 101.5, 50.0, 51.5);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var row = page.locator("tbody#logbook-body tr.log-row[data-id='" + log.getId() + "']");
+        assertThat(row).hasCount(1);
+        assertThat(row.locator("input[name='fromAirport']")).hasValue("KAAA");
+        assertThat(row.locator("input[name='toAirport']")).hasValue("KBBB");
+        assertThat(row.locator("input[name='hobbsOut']")).hasValue("100.0");
+        assertThat(row.locator("input[name='hobbsIn']")).hasValue("101.5");
+        assertThat(row.locator("input[name='tachOut']")).hasValue("50.0");
+        assertThat(row.locator("input[name='tachIn']")).hasValue("51.5");
+
+        // Inputs must stay readonly — the row table is display-only; users
+        // edit via the add-row + delete only.
+        assertThat(row.locator("input[name='fromAirport']")).hasAttribute("readonly", "");
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void nullAirportsAndHoursRenderEmptyWithoutBreaking() {
+        // FlightLog columns are all nullable; render must tolerate it.
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        FlightLog log = saveLog(u, null, null, null, null, null, null);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var row = page.locator("tbody#logbook-body tr.log-row[data-id='" + log.getId() + "']");
+        assertThat(row).hasCount(1);
+        assertThat(row.locator("input[name='fromAirport']")).hasValue("");
+        assertThat(row.locator("input[name='toAirport']")).hasValue("");
+        assertThat(row.locator("input[name='hobbsOut']")).hasValue("");
+        assertThat(row.locator("input[name='hobbsIn']")).hasValue("");
+        assertThat(row.locator("input[name='tachOut']")).hasValue("");
+        assertThat(row.locator("input[name='tachIn']")).hasValue("");
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void zeroDurationLegRendersWithZeroValues() {
+        // Edge case: a log where the meter values are all zero, e.g. a
+        // brand-new airframe getting its first ground-test entry.
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        FlightLog log = saveLog(u, "KAAA", "KAAA", 0.0, 0.0, 0.0, 0.0);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var row = page.locator("tbody#logbook-body tr.log-row[data-id='" + log.getId() + "']");
+        assertThat(row.locator("input[name='hobbsOut']")).hasValue("0.0");
+        assertThat(row.locator("input[name='hobbsIn']")).hasValue("0.0");
+        assertThat(row.locator("input[name='tachOut']")).hasValue("0.0");
+        assertThat(row.locator("input[name='tachIn']")).hasValue("0.0");
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void veryLargeHoursValueRenders() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        FlightLog log = saveLog(u, "KAAA", "KBBB", 99998.5, 99999.9, 99998.5, 99999.9);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var row = page.locator("tbody#logbook-body tr.log-row[data-id='" + log.getId() + "']");
+        assertThat(row.locator("input[name='hobbsIn']")).hasValue("99999.9");
+        assertThat(row.locator("input[name='tachIn']")).hasValue("99999.9");
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void specialCharsInAirportFieldsAreEscapedNotInterpreted() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        // Airport fields are free-text in the UI — injection-shaped input
+        // must round-trip as plain text, not interpreted markup.
+        String inj = "<script>window.__pwnedLog=1</script>";
+        FlightLog log = saveLog(u, inj, "K\"B&B'C", 1.0, 2.0, 1.0, 2.0);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var row = page.locator("tbody#logbook-body tr.log-row[data-id='" + log.getId() + "']");
+        assertThat(row.locator("input[name='fromAirport']")).hasValue(inj);
+        assertThat(row.locator("input[name='toAirport']")).hasValue("K\"B&B'C");
+
+        Object pwned = page.evaluate("() => window.__pwnedLog");
+        if (pwned != null) {
+            throw new AssertionError("XSS in fromAirport: window.__pwnedLog was set");
+        }
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void multipleLogRowsRenderInInsertionOrder() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        FlightLog l1 = saveLog(u, "K001", "K002", 1.0, 2.0, 1.0, 2.0);
+        FlightLog l2 = saveLog(u, "K003", "K004", 2.0, 3.0, 2.0, 3.0);
+        FlightLog l3 = saveLog(u, "K005", "K006", 3.0, 4.0, 3.0, 4.0);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var rows = page.locator("tbody#logbook-body tr.log-row");
+        assertThat(rows).hasCount(3);
+        // Insertion order = primary-key ascending = JpaRepository default.
+        assertThat(rows.nth(0).locator("input[name='fromAirport']")).hasValue("K001");
+        assertThat(rows.nth(1).locator("input[name='fromAirport']")).hasValue("K003");
+        assertThat(rows.nth(2).locator("input[name='fromAirport']")).hasValue("K005");
+        // Sanity: ids match.
+        assertThat(rows.nth(0)).hasAttribute("data-id", String.valueOf(l1.getId()));
+        assertThat(rows.nth(1)).hasAttribute("data-id", String.valueOf(l2.getId()));
+        assertThat(rows.nth(2)).hasAttribute("data-id", String.valueOf(l3.getId()));
+
+        assertNoConsoleErrors(errors);
+    }
+}

--- a/src/browserTest/java/com/example/AviaryService/browser/HoursTableEdgeCasesTest.java
+++ b/src/browserTest/java/com/example/AviaryService/browser/HoursTableEdgeCasesTest.java
@@ -1,0 +1,197 @@
+package com.example.AviaryService.browser;
+
+import com.example.AviaryService.entity.User;
+import com.example.AviaryService.repositories.UserRepository;
+import com.microsoft.playwright.options.LoadState;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+/**
+ * Edge-case rendering tests for the "My Hours" block and the aircraft-info
+ * table on the dashboard. Seeds a User row with edge-case values, loads
+ * /dashboard, asserts the cells render the expected text and the page
+ * produces no console errors.
+ *
+ * Add a new test here every time something about the My Hours UI is
+ * fixed or extended.
+ */
+class HoursTableEdgeCasesTest extends BrowserTestBase {
+
+    @Autowired
+    UserRepository users;
+
+    /** Hook the console-error listener BEFORE navigating. Returns the captured-errors list. */
+    private List<String> attachConsoleErrorListener() {
+        List<String> errors = new ArrayList<>();
+        page.onConsoleMessage(msg -> {
+            if ("error".equals(msg.type())) errors.add(msg.text());
+        });
+        return errors;
+    }
+
+    private void assertNoConsoleErrors(List<String> errors) {
+        if (!errors.isEmpty()) throw new AssertionError("Console errors: " + errors);
+    }
+
+    @Test
+    void freshUserShowsZeroHoursAndEmptyAircraftInfo() {
+        // User with no edits — getHobbsHours/getTachHours default to 0.0,
+        // aircraft info fields are null.
+        String username = seedUser("password");
+        List<String> errors = attachConsoleErrorListener();
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // Hours block always renders "Hobbs Time: 0.0" / "Tach Time: 0.0" for
+        // a brand-new user because the getters coalesce null → 0.0.
+        assertThat(page.locator("#current-hobbs-display")).containsText("Hobbs Time:");
+        assertThat(page.locator("#current-hobbs-display")).containsText("0");
+        assertThat(page.locator("#current-tach-display")).containsText("Tach Time:");
+        assertThat(page.locator("#current-tach-display")).containsText("0");
+
+        // Aircraft info inputs are empty for a fresh user.
+        assertThat(page.locator("input[name='makeModel']")).hasValue("");
+        assertThat(page.locator("input[name='tailNumber']")).hasValue("");
+        assertThat(page.locator("input[name='ownerName']")).hasValue("");
+        assertThat(page.locator("input[name='makeModelSN']")).hasValue("");
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void decimalHoursRenderWithoutTruncation() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        u.setHobbsHours(1234.5);
+        u.setTachHours(987.6);
+        users.save(u);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // The display string is built by Thymeleaf string-concat which uses
+        // Double.toString(); 1234.5 should appear verbatim.
+        assertThat(page.locator("#current-hobbs-display")).containsText("1234.5");
+        assertThat(page.locator("#current-tach-display")).containsText("987.6");
+
+        // The "Edit" form input mirrors the same value.
+        assertThat(page.locator("#current-hobbs")).hasValue("1234.5");
+        assertThat(page.locator("#current-tach")).hasValue("987.6");
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void veryLargeHoursValueRenders() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        u.setHobbsHours(99999.9);
+        u.setTachHours(99999.9);
+        users.save(u);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        assertThat(page.locator("#current-hobbs-display")).containsText("99999.9");
+        assertThat(page.locator("#current-tach-display")).containsText("99999.9");
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void aircraftInfoFieldsPopulateInputs() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        u.setMakeModel("Cessna 172");
+        u.setTailNumber("N12345");
+        u.setOwnerName("Daniel I.");
+        u.setMakeModelSN("17280342");
+        users.save(u);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        assertThat(page.locator("input[name='makeModel']")).hasValue("Cessna 172");
+        assertThat(page.locator("input[name='tailNumber']")).hasValue("N12345");
+        assertThat(page.locator("input[name='ownerName']")).hasValue("Daniel I.");
+        assertThat(page.locator("input[name='makeModelSN']")).hasValue("17280342");
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void specialCharsInAircraftInfoDoNotBreakRendering() {
+        // Specifically check HTML-special chars are escaped, not interpreted.
+        // If the template forgot th:value escaping somewhere, "<script>" would
+        // break the input and surface as a console/parse error.
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        u.setMakeModel("Boeing & Sons \"Best\" <model>");
+        u.setTailNumber("N-1'2\"3");
+        users.save(u);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // Round-trips through HTML attribute escape; input.value should equal
+        // the original string.
+        assertThat(page.locator("input[name='makeModel']")).hasValue("Boeing & Sons \"Best\" <model>");
+        assertThat(page.locator("input[name='tailNumber']")).hasValue("N-1'2\"3");
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void zeroHoursRendersWithoutCollapsingToEmpty() {
+        // Regression-shaped test: a zero value is a legitimate value and must
+        // not render as blank.
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        u.setHobbsHours(0.0);
+        u.setTachHours(0.0);
+        users.save(u);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // "Hobbs Time: 0.0" must include the "0" — not "Hobbs Time: ".
+        assertThat(page.locator("#current-hobbs-display")).containsText("Hobbs Time:");
+        assertThat(page.locator("#current-hobbs-display")).containsText("0");
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void manualSourceStampSetsHoursUpdatedDataAttributes() {
+        // The hours-updated span exposes data-updated + data-source which
+        // dashboard.js reads to render the "last updated" label.
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        u.setHobbsHours(50.0);
+        u.setHobbsUpdatedAt(java.time.Instant.parse("2025-10-01T12:00:00Z"));
+        u.setHobbsUpdatedSource("manual");
+        users.save(u);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        assertThat(page.locator("#hobbs-updated"))
+                .hasAttribute("data-source", "manual");
+        assertThat(page.locator("#hobbs-updated"))
+                .hasAttribute("data-updated", "2025-10-01T12:00:00Z");
+
+        assertNoConsoleErrors(errors);
+    }
+}

--- a/src/browserTest/java/com/example/AviaryService/browser/LoginSmokeTest.java
+++ b/src/browserTest/java/com/example/AviaryService/browser/LoginSmokeTest.java
@@ -1,0 +1,51 @@
+package com.example.AviaryService.browser;
+
+import com.microsoft.playwright.options.LoadState;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+/**
+ * Smoke test: proves the whole browser-test rig works end-to-end before
+ * we write real edge-case tests. Seeds a user, logs in via the real
+ * /login form, asserts the dashboard renders without console errors.
+ *
+ * If this passes, the infra is good and we can layer table-specific
+ * edge-case tests on top.
+ */
+class LoginSmokeTest extends BrowserTestBase {
+
+    @Test
+    void seededUserCanLogInAndSeeDashboard() {
+        String username = seedUser("password123");
+
+        // Capture browser console errors during the whole flow — silent JS
+        // errors are exactly the kind of bug Playwright is supposed to
+        // catch and pure backend tests miss.
+        List<String> consoleErrors = new ArrayList<>();
+        page.onConsoleMessage(msg -> {
+            if ("error".equals(msg.type())) {
+                consoleErrors.add(msg.text());
+            }
+        });
+
+        loginAs(username, "password123");
+
+        // Wait for the dashboard JS to settle (Thymeleaf renders synchronously
+        // but dashboard.js may fetch/transform on load).
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // Sanity: the page is the dashboard, not the login page after a
+        // failed redirect.
+        assertThat(page).hasURL(baseUrl() + "/dashboard");
+        assertThat(page.locator("body")).isVisible();
+
+        // No console errors during render.
+        if (!consoleErrors.isEmpty()) {
+            throw new AssertionError("Console errors during dashboard render: " + consoleErrors);
+        }
+    }
+}

--- a/src/browserTest/java/com/example/AviaryService/browser/ServiceTimelineGridTest.java
+++ b/src/browserTest/java/com/example/AviaryService/browser/ServiceTimelineGridTest.java
@@ -1,0 +1,240 @@
+package com.example.AviaryService.browser;
+
+import com.example.AviaryService.entity.ServiceTimeline;
+import com.example.AviaryService.entity.User;
+import com.example.AviaryService.repositories.ServiceTimelineRepository;
+import com.example.AviaryService.repositories.UserRepository;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.LoadState;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Regression tests for the "continuous grid" service-timeline redesign.
+ *
+ * The redesign made every cell's field fill its whole grid cell (borderless,
+ * vertically centered) so there is no dead gap above/below short controls when
+ * the two-line Cycle column makes a row tall. It also:
+ *  - tucks the "hrs" suffix INSIDE the Cycle cell (it used to spill out),
+ *  - splits the Cycle cell into two hairline-separated halves,
+ *  - shows an "Add date / hrs" placeholder in empty Last Done / Due Date cells,
+ *  - makes the Item/Title picker a segmented control with EQUAL-width segments,
+ *  - pads the Add button inside its cell so it never touches the cell border.
+ *
+ * These tests guard each of those against regressions and drop before/after
+ * screenshots (saved row + add row) at two desktop widths into the build report.
+ */
+class ServiceTimelineGridTest extends BrowserTestBase {
+
+    @Autowired
+    UserRepository users;
+
+    @Autowired
+    ServiceTimelineRepository timelines;
+
+    /** A title row + one item row whose two-line Cycle makes the row tall. */
+    private long seedTallCycleRow(User user) {
+        ServiceTimeline title = new ServiceTimeline();
+        title.setUser(user);
+        title.setItem("ENGINE - LEFT");
+        title.setIsTitle(true);
+        title.setTimelineOrder(1);
+        timelines.save(title);
+
+        ServiceTimeline t = new ServiceTimeline();
+        t.setUser(user);
+        t.setItem("Oil & filter change");
+        t.setIsTitle(false);
+        t.setTimelineOrder(2);
+        t.setDescription("Inspect");
+        t.setCycleCalendarValue(50);
+        t.setCycleCalendarUnit("DAYS");
+        t.setCycleHours(25.0);
+        t.setLastDone("");   // empty → exercises the "Add date / hrs" placeholder
+        t.setDueDate("");
+        t.setTimeLeft("");
+        timelines.save(t);
+        return t.getId();
+    }
+
+    /** getBoundingClientRect into [x, y, w, h]. */
+    private double[] rectOf(Locator loc) {
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> r = (java.util.Map<String, Object>) loc.evaluate(
+                "el => { const r = el.getBoundingClientRect();"
+                + " return { x: r.x, y: r.y, w: r.width, h: r.height }; }");
+        return new double[] {
+                ((Number) r.get("x")).doubleValue(),
+                ((Number) r.get("y")).doubleValue(),
+                ((Number) r.get("w")).doubleValue(),
+                ((Number) r.get("h")).doubleValue()
+        };
+    }
+
+    private String beforeContent(Locator loc) {
+        return (String) loc.evaluate("el => getComputedStyle(el, '::before').content");
+    }
+
+    @Test
+    void hrsSuffixStaysInsideTheCycleCell() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        long id = seedTallCycleRow(u);
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+        page.setViewportSize(1280, 800);
+
+        var cell = page.locator("tr.auto-save-row[data-id='" + id + "'] td:nth-child(4)");
+        var hrs  = page.locator("tr.auto-save-row[data-id='" + id + "'] .cycle-unit-label");
+
+        double[] cellR = rectOf(cell);
+        double[] hrsR  = rectOf(hrs);
+
+        // The "hrs" label must sit fully inside the Cycle cell horizontally.
+        if (hrsR[0] + hrsR[2] > cellR[0] + cellR[2] + 0.5) {
+            throw new AssertionError("'hrs' right edge " + (hrsR[0] + hrsR[2])
+                    + " spills past Cycle cell right edge " + (cellR[0] + cellR[2]));
+        }
+        if (hrsR[0] < cellR[0] - 0.5) {
+            throw new AssertionError("'hrs' left edge spills left of the Cycle cell");
+        }
+    }
+
+    @Test
+    void cycleCellIsSplitIntoTwoHairlineHalves() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        long id = seedTallCycleRow(u);
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var rows = page.locator("tr.auto-save-row[data-id='" + id + "'] td:nth-child(4) .cycle-row");
+        if (rows.count() != 2) {
+            throw new AssertionError("Cycle cell should have exactly 2 rows, found " + rows.count());
+        }
+        // First half carries the hairline divider; second half does not.
+        String firstBorder = (String) rows.nth(0).evaluate(
+                "el => getComputedStyle(el).borderBottomStyle");
+        if ("none".equals(firstBorder)) {
+            throw new AssertionError("First cycle row should have a hairline divider (border-bottom)");
+        }
+    }
+
+    @Test
+    void shortFieldCellsAreVerticallyCenteredWithNoTopGap() {
+        // The whole point of the redesign: in a tall row, a single short control
+        // (Description) must be vertically CENTERED in its cell, not pinned to the
+        // top with dead space below. Assert its vertical center is within a few px
+        // of the row's vertical center.
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        long id = seedTallCycleRow(u);
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+        page.setViewportSize(1280, 800);
+
+        var row  = page.locator("tr.auto-save-row[data-id='" + id + "']");
+        var desc = page.locator("tr.auto-save-row[data-id='" + id + "'] td:nth-child(3) .selected-option");
+
+        double[] rowR  = rectOf(row);
+        double[] descR = rectOf(desc);
+
+        double rowMid  = rowR[1] + rowR[3] / 2.0;
+        double descMid = descR[1] + descR[3] / 2.0;
+
+        // Tall row (two-line Cycle) — the control must be centered, not top-pinned.
+        if (rowR[3] < 48) {
+            throw new AssertionError("Row should be tall (two-line Cycle), was " + rowR[3] + "px");
+        }
+        if (Math.abs(descMid - rowMid) > 8.0) {
+            throw new AssertionError("Description control mid " + descMid
+                    + " is not centered in row (mid " + rowMid + ") — looks top-pinned with a gap");
+        }
+    }
+
+    @Test
+    void emptyDateCellShowsAddDatePlaceholder() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        long id = seedTallCycleRow(u);   // lastDone / dueDate are empty
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var dueWrapper = page.locator(
+                "tr.auto-save-row[data-id='" + id + "'] td:nth-child(6) .input-with-dropdown");
+        String content = beforeContent(dueWrapper);
+        if (content == null || !content.contains("Add date")) {
+            throw new AssertionError("Empty Due Date cell should show an 'Add date' placeholder, got: " + content);
+        }
+    }
+
+    @Test
+    void itemTitleToggleSegmentsAreEqualWidth() {
+        String username = seedUser("password");
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+        page.setViewportSize(1280, 800);
+
+        var options = page.locator(".add-row .row-type-option");
+        if (options.count() != 2) {
+            throw new AssertionError("Expected 2 row-type segments, found " + options.count());
+        }
+        double itemW  = rectOf(options.nth(0))[2];
+        double titleW = rectOf(options.nth(1))[2];
+        if (Math.abs(itemW - titleW) > 1.0) {
+            throw new AssertionError("Item/Title segments should be equal width — Item " + itemW
+                    + "px vs Title " + titleW + "px");
+        }
+    }
+
+    @Test
+    void addButtonIsPaddedInsideItsCellNotTouchingTheBorder() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        seedTallCycleRow(u);
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+        page.setViewportSize(1280, 800);
+
+        var cell   = page.locator(".add-row td.add-cell");
+        var button = page.locator(".add-row td.add-cell button.add-button");
+        double[] cellR = rectOf(cell);
+        double[] btnR  = rectOf(button);
+
+        // There must be real horizontal padding on both sides (≥6px each).
+        double leftPad  = btnR[0] - cellR[0];
+        double rightPad = (cellR[0] + cellR[2]) - (btnR[0] + btnR[2]);
+        if (leftPad < 6.0 || rightPad < 6.0) {
+            throw new AssertionError("Add button not padded inside its cell — leftPad=" + leftPad
+                    + " rightPad=" + rightPad);
+        }
+    }
+
+    @Test
+    void screenshotsSavedAndAddRowsAtMultipleDesktopWidths() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        seedTallCycleRow(u);
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        for (int w : new int[] { 1280, 1024, 980 }) {
+            page.setViewportSize(w, 800);
+            page.waitForLoadState(LoadState.NETWORKIDLE);
+            Path shot = Paths.get("build", "reports", "browserTest-screenshots",
+                    "timeline-grid-" + w + ".png");
+            shot.toFile().getParentFile().mkdirs();
+            page.screenshot(new Page.ScreenshotOptions().setPath(shot).setFullPage(true));
+        }
+    }
+}

--- a/src/browserTest/java/com/example/AviaryService/browser/ServiceTimelineMobileLayoutTest.java
+++ b/src/browserTest/java/com/example/AviaryService/browser/ServiceTimelineMobileLayoutTest.java
@@ -1,0 +1,392 @@
+package com.example.AviaryService.browser;
+
+import com.example.AviaryService.entity.ServiceTimeline;
+import com.example.AviaryService.entity.User;
+import com.example.AviaryService.repositories.ServiceTimelineRepository;
+import com.example.AviaryService.repositories.UserRepository;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.BoundingBox;
+import com.microsoft.playwright.options.LoadState;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the mobile service-timeline layout redesign:
+ *
+ *  - each saved item card lays out 1 / 2-2 / 1 (Item headline full width;
+ *    Description|Last Done; Cycle|Due Date; Time Left full width), so the left
+ *    column is Description+Cycle and the right column is Last Done+Due Date,
+ *  - tapping the Item headline collapses the card to just its name and tapping
+ *    again expands it (cards are expanded by default),
+ *  - in the Add row, choosing "Title" REMOVES the item-only fields (Description,
+ *    Cycle, Last Done, Due Date, Time Left) rather than leaving empty space.
+ *
+ * Screenshots of the collapsed card and the title-mode add row are dropped into
+ * the build report.
+ */
+class ServiceTimelineMobileLayoutTest extends BrowserTestBase {
+
+    private static final int PHONE_W = 390;
+    private static final int PHONE_H = 844;
+
+    @Autowired
+    UserRepository users;
+
+    @Autowired
+    ServiceTimelineRepository timelines;
+
+    private void seedData(User user) {
+        ServiceTimeline title = new ServiceTimeline();
+        title.setUser(user);
+        title.setItem("ENGINE");
+        title.setIsTitle(true);
+        title.setTimelineOrder(0);
+        timelines.save(title);
+
+        ServiceTimeline item = new ServiceTimeline();
+        item.setUser(user);
+        item.setItem("Annual Inspection");
+        item.setIsTitle(false);
+        item.setTimelineOrder(1);
+        item.setDescription("Inspect");
+        item.setCycleCalendarValue(12);
+        item.setCycleCalendarUnit("MONTHS");
+        item.setCycleHours(100.0);
+        item.setLastDone("2025-06-01");
+        item.setDueDate("2026-06-01 2450.0");
+        item.setTimeLeft("11 mo\n86.0 hrs");
+        timelines.save(item);
+    }
+
+    private double[] rectOf(Locator loc) {
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> r = (java.util.Map<String, Object>) loc.evaluate(
+                "el => { const r = el.getBoundingClientRect();"
+                + " return { x: r.x, y: r.y, w: r.width, h: r.height }; }");
+        return new double[] {
+                ((Number) r.get("x")).doubleValue(),
+                ((Number) r.get("y")).doubleValue(),
+                ((Number) r.get("w")).doubleValue(),
+                ((Number) r.get("h")).doubleValue()
+        };
+    }
+
+    private void openDashboardOnPhone() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        seedData(u);
+        page.setViewportSize(PHONE_W, PHONE_H);
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+        // Last Done / Due Date inputs are injected by JS from the row's
+        // data-* attributes on load — wait for one before measuring.
+        page.locator("tr.auto-save-row td[data-label='Due Date'] input.extra-input")
+                .first().waitFor();
+    }
+
+    @Test
+    void cardLaysOutOneTwoTwoOne() {
+        openDashboardOnPhone();
+
+        Locator row = page.locator("tr.auto-save-row").first();
+        double[] rowR = rectOf(row);
+
+        double[] item = rectOf(row.locator("td[data-label='Item']"));
+        double[] desc = rectOf(row.locator("td[data-label='Description']"));
+        double[] cyc  = rectOf(row.locator("td[data-label='Cycle']"));
+        double[] last = rectOf(row.locator("td[data-label='Last Done']"));
+        double[] due  = rectOf(row.locator("td[data-label='Due Date']"));
+        double[] time = rectOf(row.locator("td[data-label='Time Left']"));
+
+        // Item is a full-width headline at the top.
+        assertTrue(item[2] > rowR[2] * 0.8,
+                "Item should span (nearly) the full card width — was " + item[2] + " of " + rowR[2]);
+
+        // Row 2: Description (left) and Last Done (right) sit side by side.
+        assertTrue(Math.abs(desc[1] - last[1]) < 6,
+                "Description and Last Done should share a row (y " + desc[1] + " vs " + last[1] + ")");
+        assertTrue(desc[0] < last[0],
+                "Description should be in the LEFT column, Last Done in the RIGHT");
+
+        // Row 3: Cycle (left) and Due Date (right) sit side by side, BELOW row 2.
+        assertTrue(Math.abs(cyc[1] - due[1]) < 6,
+                "Cycle and Due Date should share a row (y " + cyc[1] + " vs " + due[1] + ")");
+        assertTrue(cyc[0] < due[0],
+                "Cycle should be in the LEFT column, Due Date in the RIGHT");
+        assertTrue(cyc[1] > desc[1] + 5,
+                "Cycle row should be below the Description row");
+
+        // Left column shares an x; right column shares an x.
+        assertTrue(Math.abs(desc[0] - cyc[0]) < 4,
+                "Description and Cycle should share the LEFT column x (" + desc[0] + " vs " + cyc[0] + ")");
+        assertTrue(Math.abs(last[0] - due[0]) < 4,
+                "Last Done and Due Date should share the RIGHT column x (" + last[0] + " vs " + due[0] + ")");
+
+        // Time Left is full width at the bottom of the field block.
+        assertTrue(time[2] > rowR[2] * 0.8,
+                "Time Left should span (nearly) the full card width — was " + time[2]);
+        assertTrue(time[1] > cyc[1] + 5,
+                "Time Left should sit below the Cycle / Due Date row");
+    }
+
+    @Test
+    void tappingItemHeadlineCollapsesAndExpands() {
+        openDashboardOnPhone();
+
+        Locator row = page.locator("tr.auto-save-row").first();
+        Locator itemCell = row.locator("td[data-label='Item']");
+        Locator descCell = row.locator("td[data-label='Description']");
+        Locator caret = row.locator("td[data-label='Item'] .card-caret");
+
+        // Expanded by default.
+        assertTrue(descCell.isVisible(), "Card should be expanded by default");
+        assertFalse(((String) row.getAttribute("class")).contains("collapsed"),
+                "Card should not start collapsed");
+        String caretExpanded = cssOf(caret, "transform");
+
+        // Tap the caret area on the right of the headline (not the textarea).
+        BoundingBox b = itemCell.boundingBox();
+        itemCell.click(new Locator.ClickOptions().setPosition(b.width - 8, b.height / 2));
+
+        assertTrue(((String) row.getAttribute("class")).contains("collapsed"),
+                "Tapping the headline should collapse the card");
+        assertFalse(descCell.isVisible(),
+                "Collapsed card should hide everything except the Item name");
+        assertNotEquals(caretExpanded, cssOf(caret, "transform"),
+                "Collapse arrow should rotate when the card is collapsed");
+
+        Path shot = Paths.get("build", "browsertest-screenshots", "mobile-card-collapsed.png");
+        try {
+            Files.createDirectories(shot.getParent());
+        } catch (Exception ignored) { }
+        page.screenshot(new Page.ScreenshotOptions().setPath(shot).setFullPage(true));
+
+        // Tap again (anywhere on the collapsed card) to re-expand.
+        itemCell.click(new Locator.ClickOptions().setPosition(b.width - 8, b.height / 2));
+        assertFalse(((String) row.getAttribute("class")).contains("collapsed"),
+                "Tapping again should re-expand the card");
+        assertTrue(descCell.isVisible(), "Re-expanded card should show its fields again");
+    }
+
+    @Test
+    void addRowTitleModeRemovesItemOnlyFields() {
+        openDashboardOnPhone();
+
+        Locator addRow = page.locator(".add-row");
+        // Default is "item" mode — fields visible.
+        assertTrue(addRow.locator("td[data-label='Cycle']").isVisible(),
+                "Cycle field should be visible while adding an Item");
+
+        // Switch to "Title" mode.
+        addRow.locator(".row-type-option[data-type='title']").click();
+
+        assertTrue(page.locator("#titleInput input").isVisible(),
+                "Title input should be visible in title mode");
+        for (String label : new String[] { "Description", "Cycle", "Last Done", "Due Date", "Time Left" }) {
+            assertFalse(addRow.locator("td[data-label='" + label + "']").isVisible(),
+                    label + " field should be removed (not shown) while adding a Title");
+        }
+
+        Path shot = Paths.get("build", "browsertest-screenshots", "mobile-addrow-title-mode.png");
+        try {
+            Files.createDirectories(shot.getParent());
+        } catch (Exception ignored) { }
+        page.screenshot(new Page.ScreenshotOptions().setPath(shot).setFullPage(true));
+
+        // Switch back to "Item" — fields return.
+        addRow.locator(".row-type-option[data-type='item']").click();
+        assertTrue(addRow.locator("td[data-label='Cycle']").isVisible(),
+                "Cycle field should return when switching back to Item");
+    }
+
+    private String cssOf(Locator loc, String prop) {
+        return (String) loc.evaluate("(el, p) => getComputedStyle(el).getPropertyValue(p)", prop);
+    }
+
+    @Test
+    void addRowUsesSameOneTwoTwoOneGridLayout() {
+        openDashboardOnPhone();
+
+        Locator addRow = page.locator(".add-row");
+        assertEquals("grid", cssOf(addRow, "display"),
+                "Add row should lay out as a CSS grid like the saved cards");
+
+        double[] desc = rectOf(addRow.locator("td[data-label='Description']"));
+        double[] cyc  = rectOf(addRow.locator("td[data-label='Cycle']"));
+        double[] last = rectOf(addRow.locator("td[data-label='Last Done']"));
+        double[] due  = rectOf(addRow.locator("td[data-label='Due Date']"));
+
+        assertTrue(Math.abs(desc[1] - last[1]) < 6,
+                "Add row: Description and Last Done should share a row");
+        assertTrue(desc[0] < last[0],
+                "Add row: Description should be LEFT, Last Done RIGHT");
+        assertTrue(Math.abs(cyc[1] - due[1]) < 6,
+                "Add row: Cycle and Due Date should share a row");
+        assertTrue(cyc[0] < due[0],
+                "Add row: Cycle should be LEFT, Due Date RIGHT");
+        assertTrue(cyc[1] > desc[1] + 5,
+                "Add row: Cycle row should be below the Description row");
+    }
+
+    @Test
+    void cycleUnitArrowIsRestyledToFaChevron() {
+        openDashboardOnPhone();
+
+        Locator unit = page.locator("tr.auto-save-row td[data-label='Cycle'] select.cycle-unit").first();
+        // Native select arrow removed...
+        String appearance = cssOf(unit, "appearance");
+        assertTrue("none".equals(appearance) || "none".equals(cssOf(unit, "-webkit-appearance")),
+                "Cycle unit should drop the native select arrow (appearance:none), was " + appearance);
+        // ...and replaced by an SVG chevron background, matching the other fields.
+        String bg = cssOf(unit, "background-image");
+        assertTrue(bg != null && bg.contains("svg"),
+                "Cycle unit should show an SVG chevron background, was " + bg);
+    }
+
+    @Test
+    void cardArrowIsBigFontAwesomeChevron() {
+        openDashboardOnPhone();
+
+        Locator caret = page.locator("tr.auto-save-row td[data-label='Item'] .card-caret").first();
+        String cls = (String) caret.getAttribute("class");
+        assertTrue(cls != null && cls.contains("fa-chevron-down"),
+                "Card arrow should be a fa-chevron-down icon, classes: " + cls);
+        assertFalse("none".equals(cssOf(caret, "display")),
+                "Card arrow should be visible on mobile");
+        double size = Double.parseDouble(cssOf(caret, "font-size").replace("px", "").trim());
+        assertTrue(size >= 18,
+                "Card arrow should be bigger than the field arrows (>=18px), was " + size);
+    }
+
+    @Test
+    void timeLeftIsHorizontallyCentered() {
+        openDashboardOnPhone();
+        Locator timeLeft = page.locator("tr.auto-save-row .time-left").first();
+        assertEquals("center", cssOf(timeLeft, "text-align"),
+                "Time Left should be horizontally centered");
+    }
+
+    @Test
+    void serviceTimelineNeverOverflowsViewportAcrossBreakpoints() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        seedData(u);
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        int[] widths = { 769, 780, 800, 850, 900, 950, 1000, 1024 };
+        StringBuilder over = new StringBuilder();
+        for (int w : widths) {
+            page.setViewportSize(w, 900);
+            page.waitForTimeout(80);
+            long scrollW = ((Number) page.evaluate("() => document.documentElement.scrollWidth")).longValue();
+            long innerW = ((Number) page.evaluate("() => window.innerWidth")).longValue();
+            if (scrollW > innerW + 1) {
+                over.append(" [w=").append(w).append(": scrollWidth=").append(scrollW)
+                    .append(" > innerWidth=").append(innerW).append("]");
+            }
+            // Visual evidence at a width that used to overflow with the desktop table.
+            if (w == 850) {
+                Path shot = Paths.get("build", "browsertest-screenshots", "timeline-850-no-overflow.png");
+                try {
+                    Files.createDirectories(shot.getParent());
+                } catch (Exception ignored) { }
+                page.screenshot(new Page.ScreenshotOptions().setPath(shot).setFullPage(true));
+            }
+        }
+        if (over.length() > 0) {
+            throw new AssertionError("Service timeline overflows the viewport at:" + over);
+        }
+    }
+
+    @Test
+    void cardCellsHaveSeparatingBorders() {
+        openDashboardOnPhone();
+        Locator descCell = page.locator("tr.auto-save-row td[data-label='Description']").first();
+        assertEquals("solid", cssOf(descCell, "border-bottom-style"),
+                "Cells should have a bottom border separating rows");
+        assertEquals("solid", cssOf(descCell, "border-right-style"),
+                "Left-column cells should have a right border separating columns");
+    }
+
+    @Test
+    void collapseTogglesInCardModeButNotOnDesktop() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        seedData(u);
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // Desktop table (>960px): tapping the item must NOT collapse the row.
+        page.setViewportSize(1000, 900);
+        page.waitForTimeout(80);
+        Locator row = page.locator("tr.auto-save-row").first();
+        row.locator("td[data-label='Item']").click();
+        assertFalse(((String) row.getAttribute("class")).contains("collapsed"),
+                "Desktop table rows must not collapse on click");
+
+        // Wide card mode (769–960px): tapping the item title SHOULD collapse it.
+        page.setViewportSize(900, 900);
+        page.waitForTimeout(80);
+        Locator itemCell = row.locator("td[data-label='Item']");
+        BoundingBox b = itemCell.boundingBox();
+        itemCell.click(new Locator.ClickOptions().setPosition(b.width - 8, b.height / 2));
+        assertTrue(((String) row.getAttribute("class")).contains("collapsed"),
+                "At 900px (card mode) tapping the item title should collapse the card");
+    }
+
+    @Test
+    void addRowItemNameIsCentered() {
+        openDashboardOnPhone();
+        Locator itemInput = page.locator(".add-row td[data-label='Item'] textarea");
+        assertEquals("center", cssOf(itemInput, "text-align"),
+                "The add-row item name input should be horizontally centered");
+    }
+
+    @Test
+    void addRowCycleDoesNotOverlapTimeLeft() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        seedData(u);
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        for (int w : new int[] { 390, 700, 900 }) {
+            page.setViewportSize(w, 900);
+            page.waitForTimeout(80);
+            double[] hrsRow = rectOf(page.locator(".add-row td[data-label='Cycle'] .cycle-row").last());
+            double[] timeLeft = rectOf(page.locator(".add-row td[data-label='Time Left']"));
+            double hrsBottom = hrsRow[1] + hrsRow[3];
+            double tlTop = timeLeft[1];
+            assertTrue(hrsBottom <= tlTop + 1,
+                    "At " + w + "px the cycle hours row (bottom " + hrsBottom
+                    + ") must not overlap Time Left (top " + tlTop + ")");
+            if (w == 900) {
+                Path shot = Paths.get("build", "browsertest-screenshots", "addrow-900-cycle-fixed.png");
+                try {
+                    Files.createDirectories(shot.getParent());
+                } catch (Exception ignored) { }
+                page.screenshot(new Page.ScreenshotOptions().setPath(shot).setFullPage(true));
+            }
+        }
+    }
+
+    @Test
+    void cycleChevronMatchesFieldChevronSize() {
+        openDashboardOnPhone();
+        Locator unit = page.locator("tr.auto-save-row td[data-label='Cycle'] select.cycle-unit").first();
+        String bgSize = cssOf(unit, "background-size");
+        assertTrue(bgSize != null && bgSize.contains("14px"),
+                "Cycle chevron should be 14px to match the other field chevrons, was " + bgSize);
+    }
+}

--- a/src/browserTest/java/com/example/AviaryService/browser/ServiceTimelineTableEdgeCasesTest.java
+++ b/src/browserTest/java/com/example/AviaryService/browser/ServiceTimelineTableEdgeCasesTest.java
@@ -1,0 +1,244 @@
+package com.example.AviaryService.browser;
+
+import com.example.AviaryService.entity.ServiceTimeline;
+import com.example.AviaryService.entity.User;
+import com.example.AviaryService.repositories.ServiceTimelineRepository;
+import com.example.AviaryService.repositories.UserRepository;
+import com.microsoft.playwright.options.LoadState;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+/**
+ * Edge-case rendering tests for the Service Timeline table.
+ *
+ * The timeline tbody contains both title rows (.title-row) and regular
+ * item rows (.auto-save-row). Each row carries data-id; cells have
+ * data-label="..." so we can locate by column without relying on
+ * positional indexing that breaks when the schema shifts.
+ *
+ * Add a test here every time the timeline table is fixed or extended.
+ */
+class ServiceTimelineTableEdgeCasesTest extends BrowserTestBase {
+
+    @Autowired
+    UserRepository users;
+
+    @Autowired
+    ServiceTimelineRepository timelines;
+
+    private List<String> attachConsoleErrorListener() {
+        List<String> errors = new ArrayList<>();
+        page.onConsoleMessage(msg -> {
+            if ("error".equals(msg.type())) errors.add(msg.text());
+        });
+        return errors;
+    }
+
+    private void assertNoConsoleErrors(List<String> errors) {
+        if (!errors.isEmpty()) throw new AssertionError("Console errors: " + errors);
+    }
+
+    /** Build + save a regular (non-title) timeline row. */
+    private ServiceTimeline saveItem(User user, int order, String item, String description,
+                                     String lastDone, String dueDate, String timeLeft) {
+        ServiceTimeline t = new ServiceTimeline();
+        t.setUser(user);
+        t.setItem(item);
+        t.setIsTitle(false);
+        t.setTimelineOrder(order);
+        t.setDescription(description);
+        t.setLastDone(lastDone);
+        t.setDueDate(dueDate);
+        t.setTimeLeft(timeLeft);
+        return timelines.save(t);
+    }
+
+    @Test
+    void emptyTimelineRendersTableWithNoRows() {
+        String username = seedUser("password");
+        List<String> errors = attachConsoleErrorListener();
+
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // Sortable tbody exists but has zero data rows (only the add-row in a
+        // sibling tbody). No console errors during render of an empty table.
+        assertThat(page.locator("tbody.sortable .auto-save-row")).hasCount(0);
+        assertThat(page.locator("tbody.sortable .title-row")).hasCount(0);
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void titleRowRendersWithItemTextInTitleCell() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+
+        ServiceTimeline title = new ServiceTimeline();
+        title.setUser(u);
+        title.setItem("100-Hour Inspections");
+        title.setIsTitle(true);
+        title.setTimelineOrder(1);
+        timelines.save(title);
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // Title row uses td.title-cell, not the regular item textarea.
+        assertThat(page.locator("tbody.sortable tr.title-row")).hasCount(1);
+        assertThat(page.locator("tbody.sortable tr.title-row td.title-cell"))
+                .hasText("100-Hour Inspections");
+        // Regular-row count is zero.
+        assertThat(page.locator("tbody.sortable tr.auto-save-row")).hasCount(0);
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void regularRowRendersItemAndDescriptionAndDateFields() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        ServiceTimeline t = saveItem(u, 1, "Oil change", "Inspect",
+                "2025-10-01", "2025-12-01", "61 days");
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        // Locate the exact row by its data-id so column assertions are stable.
+        var row = page.locator("tr.auto-save-row[data-id='" + t.getId() + "']");
+        assertThat(row).hasCount(1);
+
+        // Item lives in the editable textarea + a print-only span.
+        assertThat(row.locator("textarea[name='item']")).hasValue("Oil change");
+        // Description is stored in a hidden input — that's what controllers read.
+        assertThat(row.locator("input[name='description'][type='hidden']"))
+                .hasValue("Inspect");
+        // Last Done + Due Date are rendered into .print-only spans. Those are
+        // display:none on screen, so Playwright's innerText-based hasText()
+        // would see empty. textContent() reads the DOM regardless of CSS.
+        String lastDone = row.locator("td[data-label='Last Done'] span.print-only")
+                .textContent();
+        if (!"2025-10-01".equals(lastDone)) {
+            throw new AssertionError("Last Done textContent was '" + lastDone + "'");
+        }
+        String dueDate = row.locator("td[data-label='Due Date'] span.print-only")
+                .textContent();
+        if (!"2025-12-01".equals(dueDate)) {
+            throw new AssertionError("Due Date textContent was '" + dueDate + "'");
+        }
+        // .time-left is recomputed by dashboard.js (calculateTimeLeft) from
+        // the row's dueDate on page load — the seeded string is overwritten.
+        // Assert the JS produced *something* date-shaped, not a literal value
+        // (date-relative strings are brittle as the calendar advances).
+        String tl = row.locator("td[data-label='Time Left'] div.time-left").textContent();
+        if (tl == null || tl.isBlank()) {
+            throw new AssertionError("Time Left should have been computed by JS, was '" + tl + "'");
+        }
+        if (!tl.contains("day") && !tl.contains("hour") && !tl.contains("today") && !tl.contains("N/A")) {
+            throw new AssertionError("Time Left looks unexpected: '" + tl + "'");
+        }
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void emptyDescriptionRendersWithoutFallingBackToHtmlDefault() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        ServiceTimeline t = saveItem(u, 1, "Item with no description", "",
+                "2025-10-01", "2025-12-01", "");
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var row = page.locator("tr.auto-save-row[data-id='" + t.getId() + "']");
+        // Empty description: the hidden input's value should be empty, not "Inspect".
+        // (We don't assert on .time-left here — JS recomputes it from dueDate,
+        // see regularRowRendersItemAndDescriptionAndDateFields.)
+        assertThat(row.locator("input[name='description'][type='hidden']"))
+                .hasValue("");
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void veryLongItemTextRendersWithoutBreakingLayout() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        // Item is a String column → Hibernate default VARCHAR(255). Pick a
+        // length that's "very long" (exercises wrapping/layout) but valid.
+        // If the column is ever widened, bump this; if it shrinks, this test
+        // will fail loudly which is the correct behaviour.
+        String longText = "X".repeat(240);
+        ServiceTimeline t = saveItem(u, 1, longText, "Inspect",
+                "2025-10-01", "2025-12-01", "61 days");
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var row = page.locator("tr.auto-save-row[data-id='" + t.getId() + "']");
+        assertThat(row.locator("textarea[name='item']")).hasValue(longText);
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void specialCharsInItemAndDescriptionAreEscapedNotInterpreted() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        // If Thymeleaf forgets to escape, this string injects markup.
+        String injection = "<script>window.__pwned=1</script> & \"quote\" 'apos'";
+        ServiceTimeline t = saveItem(u, 1, injection, injection,
+                "2025-10-01", "2025-12-01", "61 days");
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var row = page.locator("tr.auto-save-row[data-id='" + t.getId() + "']");
+        // String round-trips into both the textarea (text content) and the
+        // hidden description input (attribute value).
+        assertThat(row.locator("textarea[name='item']")).hasValue(injection);
+        assertThat(row.locator("input[name='description'][type='hidden']"))
+                .hasValue(injection);
+        // Critical: the injected script must NOT have executed.
+        Object pwned = page.evaluate("() => window.__pwned");
+        if (pwned != null) {
+            throw new AssertionError("XSS in item/description: window.__pwned was set");
+        }
+
+        assertNoConsoleErrors(errors);
+    }
+
+    @Test
+    void multipleRowsRenderInTimelineOrder() {
+        String username = seedUser("password");
+        User u = users.findByUsername(username);
+        // Insert out of order to make sure the sort actually fires.
+        saveItem(u, 3, "Third",  "Inspect", "2025-01-03", "2025-12-03", "1 day");
+        saveItem(u, 1, "First",  "Inspect", "2025-01-01", "2025-12-01", "1 day");
+        saveItem(u, 2, "Second", "Inspect", "2025-01-02", "2025-12-02", "1 day");
+
+        List<String> errors = attachConsoleErrorListener();
+        loginAs(username, "password");
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        var itemTextareas = page.locator("tr.auto-save-row textarea[name='item']");
+        assertThat(itemTextareas).hasCount(3);
+        // findByUserOrderByTimelineOrderAsc → First, Second, Third.
+        assertThat(itemTextareas.nth(0)).hasValue("First");
+        assertThat(itemTextareas.nth(1)).hasValue("Second");
+        assertThat(itemTextareas.nth(2)).hasValue("Third");
+
+        assertNoConsoleErrors(errors);
+    }
+}

--- a/src/browserTest/resources/application-browsertest.yml
+++ b/src/browserTest/resources/application-browsertest.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:browsertestdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect

--- a/src/main/java/com/example/AviaryService/controllers/UserController.java
+++ b/src/main/java/com/example/AviaryService/controllers/UserController.java
@@ -24,8 +24,6 @@ import org.slf4j.LoggerFactory;
 import jakarta.transaction.Transactional;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,12 +90,13 @@ public class UserController {
     }
 
     @GetMapping("/dashboard")
+    @Transactional
     public String showDashboard(Model model, Authentication authentication) {
         String username = authentication.getName();
         User user = userRepository.findByUsername(username);
         model.addAttribute("username", username);
         model.addAttribute("timelines", serviceTimelineRepository.findByUserOrderByTimelineOrderAsc(user));
-        model.addAttribute("descriptionOptions", descriptionOptionRepository.findByUser(user));
+        model.addAttribute("descriptionOptions", cleanupAndLoadDescriptionOptions(user));
         model.addAttribute("hobbsHours", user.getHobbsHours());
         model.addAttribute("tachHours", user.getTachHours());
 
@@ -147,6 +146,9 @@ public class UserController {
             
         }
         timeline.setCycle(cycle);
+        timeline.setCycleCalendarValue(parseIntOrNull(data.get("cycleCalendarValue")));
+        timeline.setCycleCalendarUnit(normalizeCalendarUnit(data.get("cycleCalendarUnit")));
+        timeline.setCycleHours(parseDoubleOrNull(data.get("cycleHours")));
         timeline.setLastDone(lastDone);
         timeline.setDueDate(dueDate);
         timeline.setTimeLeft(timeLeft);  // POSSIBLY REMOVE THIS !!!
@@ -196,6 +198,9 @@ public class UserController {
         response.put("item", timeline.getItem());
         response.put("description", timeline.getDescription());
         response.put("cycle", timeline.getCycle());
+        response.put("cycleCalendarValue", timeline.getCycleCalendarValue());
+        response.put("cycleCalendarUnit", timeline.getCycleCalendarUnit());
+        response.put("cycleHours", timeline.getCycleHours());
         response.put("lastDone", timeline.getLastDone());
         response.put("dueDate", timeline.getDueDate());
         response.put("timeLeft", timeline.getTimeLeft());
@@ -224,11 +229,15 @@ public ResponseEntity<Map<String, String>> updateHours(
 
         if (newHobbsTime != null) {
             user.setHobbsHours(newHobbsTime);
+            // Manual edit also sets the floor — logs can raise this, never lower it.
+            user.setHobbsManualBaseline(newHobbsTime);
             System.out.println("Setting Hobbs time to: " + newHobbsTime);
             updated = true;
         } else if (hobbsTimeToAdd != null) {
             double currentHobbs = user.getHobbsHours();
-            user.setHobbsHours(currentHobbs + hobbsTimeToAdd);
+            double newHobbs = currentHobbs + hobbsTimeToAdd;
+            user.setHobbsHours(newHobbs);
+            user.setHobbsManualBaseline(newHobbs);
             System.out.println("Adding " + hobbsTimeToAdd + " to current Hobbs: " + currentHobbs);
             updated = true;
         }
@@ -238,11 +247,14 @@ public ResponseEntity<Map<String, String>> updateHours(
 
         if (newTachTime != null) {
             user.setTachHours(newTachTime);
+            user.setTachManualBaseline(newTachTime);
             System.out.println("Setting Tach time to: " + newTachTime);
             updated = true;
         } else if (tachTimeToAdd != null) {
             double currentTach = user.getTachHours();
-            user.setTachHours(currentTach + tachTimeToAdd);
+            double newTach = currentTach + tachTimeToAdd;
+            user.setTachHours(newTach);
+            user.setTachManualBaseline(newTach);
             System.out.println("Adding " + tachTimeToAdd + " to current Tach: " + currentTach);
             updated = true;
         }
@@ -314,6 +326,12 @@ public ResponseEntity<Map<String, String>> updateHours(
                 saveCustomDescriptionOption(description, userRepository.findByUsername(authentication.getName()));
             }
             if (updateDTO.getCycle() != null) timeline.setCycle(updateDTO.getCycle());
+            // Structured cycle fields. The client sends them on every save so
+            // null actually means "clear it" here — distinguish empty/null on
+            // the client if you ever want partial updates.
+            timeline.setCycleCalendarValue(updateDTO.getCycleCalendarValue());
+            timeline.setCycleCalendarUnit(normalizeCalendarUnit(updateDTO.getCycleCalendarUnit()));
+            timeline.setCycleHours(updateDTO.getCycleHours());
             if (updateDTO.getLastDone() != null) timeline.setLastDone(updateDTO.getLastDone());
             if (updateDTO.getDueDate() != null) {
                 timeline.setDueDate(updateDTO.getDueDate());
@@ -405,14 +423,54 @@ public ResponseEntity<Map<String, String>> updateHours(
     // POST to add flight log
     @PostMapping(value = "/addflightlog", consumes = "application/json")
     @ResponseBody
+    @Transactional
     public ResponseEntity<Map<String, Object>> addFlightLog(@RequestBody FlightLog newLog, Authentication authentication) {
         User user = userRepository.findByUsername(authentication.getName());
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(errorBody("User not authenticated"));
+        }
+
+        // ── Validation ─────────────────────────────────────────────────────────
+        // Reject incomplete entries before they can corrupt displayed hours.
+        // Rule: must provide at least one COMPLETE pair (hobbsOut+hobbsIn or
+        // tachOut+tachIn). Partial pairs (e.g. only tachOut) are the exact case
+        // that used to silently wipe the user's manual hours to zero.
+        Double ho = newLog.getHobbsOut(), hi = newLog.getHobbsIn();
+        Double to = newLog.getTachOut(), ti = newLog.getTachIn();
+        boolean hobbsPair = (ho != null && hi != null);
+        boolean tachPair  = (to != null && ti != null);
+        boolean hobbsPartial = (ho == null) != (hi == null);  // exactly one set
+        boolean tachPartial  = (to == null) != (ti == null);
+
+        if (!hobbsPair && !tachPair) {
+            return ResponseEntity.badRequest().body(errorBody(
+                "Enter both Hobbs Out and Hobbs In, or both Tach Out and Tach In."));
+        }
+        if (hobbsPartial) {
+            return ResponseEntity.badRequest().body(errorBody(
+                "Hobbs entry is incomplete — enter both Hobbs Out and Hobbs In."));
+        }
+        if (tachPartial) {
+            return ResponseEntity.badRequest().body(errorBody(
+                "Tach entry is incomplete — enter both Tach Out and Tach In."));
+        }
+        if (hobbsPair && (ho < 0 || hi < 0 || hi < ho)) {
+            return ResponseEntity.badRequest().body(errorBody(
+                "Hobbs In must be ≥ Hobbs Out, and values cannot be negative."));
+        }
+        if (tachPair && (to < 0 || ti < 0 || ti < to)) {
+            return ResponseEntity.badRequest().body(errorBody(
+                "Tach In must be ≥ Tach Out, and values cannot be negative."));
+        }
+
+        // Force user ownership server-side regardless of what the client sent.
         newLog.setUser(user);
         FlightLog savedLog = flightLogRepository.save(newLog);
 
         List<FlightLog> allLogs = flightLogRepository.findByUser(user);
-        double newHobbs = calculateMergedHours(allLogs, true);
-        double newTach = calculateMergedHours(allLogs, false);
+        double newHobbs = computeDisplayedHours(user, allLogs, /*useHobbs=*/true);
+        double newTach  = computeDisplayedHours(user, allLogs, /*useHobbs=*/false);
         user.setHobbsHours(newHobbs);
         user.setTachHours(newTach);
         java.time.Instant flightNow = java.time.Instant.now();
@@ -435,6 +493,161 @@ public ResponseEntity<Map<String, String>> updateHours(
         return ResponseEntity.ok(response);
     }
 
+    private static Map<String, Object> errorBody(String message) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", "error");
+        body.put("message", message);
+        return body;
+    }
+
+    // POST: complete maintenance on a row.
+    // Server authoritatively picks "today" and "current tach hours" so the
+    // result is the same regardless of which tab the user clicks from.
+    @PostMapping("/completeMaintenance/{id}")
+    @ResponseBody
+    @Transactional
+    public ResponseEntity<Map<String, Object>> completeMaintenance(
+            @PathVariable Long id, Authentication authentication) {
+        User user = userRepository.findByUsername(authentication.getName());
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorBody("User not authenticated"));
+        }
+        ServiceTimeline timeline = serviceTimelineRepository.findById(id).orElse(null);
+        if (timeline == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorBody("Row not found"));
+        }
+        if (timeline.getUser() == null || timeline.getUser().getId() != user.getId()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorBody("You do not own this row"));
+        }
+
+        Integer calVal = timeline.getCycleCalendarValue();
+        String  calUnit = normalizeCalendarUnit(timeline.getCycleCalendarUnit());
+        Double  hrsCycle = timeline.getCycleHours();
+        boolean hasCalendar = (calVal != null && calVal > 0 && calUnit != null);
+        boolean hasHours    = (hrsCycle != null && hrsCycle > 0);
+        if (!hasCalendar && !hasHours) {
+            return ResponseEntity.badRequest().body(errorBody(
+                "Set a calendar cycle or an hours cycle before marking maintenance complete."));
+        }
+
+        java.time.LocalDate today = java.time.LocalDate.now();
+        double currentTach = user.getTachHours();
+
+        String lastDoneStr = buildDateHoursString(
+            hasCalendar ? today : null,
+            hasHours    ? currentTach : null);
+
+        java.time.LocalDate dueDateLd = null;
+        if (hasCalendar) {
+            switch (calUnit) {
+                case "DAYS":   dueDateLd = today.plusDays(calVal); break;
+                case "MONTHS": dueDateLd = today.plusMonths(calVal); break;
+                case "YEARS":  dueDateLd = today.plusYears(calVal); break;
+                default:
+                    return ResponseEntity.badRequest().body(errorBody("Invalid calendar unit: " + calUnit));
+            }
+        }
+        Double dueHours = hasHours ? (currentTach + hrsCycle) : null;
+        String dueDateStr = buildDateHoursString(dueDateLd, dueHours);
+
+        String timeLeftStr = computeTimeLeftString(dueDateLd, dueHours, today, currentTach);
+
+        timeline.setLastDone(lastDoneStr);
+        timeline.setDueDate(dueDateStr);
+        timeline.setTimeLeft(timeLeftStr);
+        serviceTimelineRepository.save(timeline);
+
+        Map<String, Object> resp = new HashMap<>();
+        resp.put("status", "ok");
+        resp.put("lastDone", lastDoneStr);
+        resp.put("dueDate", dueDateStr);
+        resp.put("timeLeft", timeLeftStr);
+        return ResponseEntity.ok(resp);
+    }
+
+    private static Integer parseIntOrNull(String s) {
+        if (s == null || s.trim().isEmpty()) return null;
+        try { return Integer.valueOf(s.trim()); } catch (NumberFormatException e) { return null; }
+    }
+
+    private static Double parseDoubleOrNull(String s) {
+        if (s == null || s.trim().isEmpty()) return null;
+        try { return Double.valueOf(s.trim()); } catch (NumberFormatException e) { return null; }
+    }
+
+    private static String normalizeCalendarUnit(String raw) {
+        if (raw == null) return null;
+        String u = raw.trim().toUpperCase();
+        if (u.isEmpty()) return null;
+        if (u.equals("DAYS") || u.equals("MONTHS") || u.equals("YEARS")) return u;
+        return null;
+    }
+
+    // Stored format matches the existing "YYYY-MM-DD <hours>" convention that
+    // the rest of the app already parses (see calculateTimeLeft in dashboard.js).
+    private static String buildDateHoursString(java.time.LocalDate date, Double hours) {
+        StringBuilder sb = new StringBuilder();
+        if (date != null) sb.append(date.toString());
+        if (hours != null) {
+            if (sb.length() > 0) sb.append(' ');
+            // Trim trailing zeros: 100.0 -> "100", 100.5 -> "100.5"
+            sb.append(hours == Math.floor(hours)
+                ? Long.toString((long) (double) hours)
+                : Double.toString(hours));
+        }
+        return sb.toString();
+    }
+
+    private static String computeTimeLeftString(java.time.LocalDate dueDate, Double dueHours,
+                                                java.time.LocalDate today, double currentTach) {
+        StringBuilder sb = new StringBuilder();
+        if (dueDate != null) {
+            long daysLeft = java.time.temporal.ChronoUnit.DAYS.between(today, dueDate);
+            sb.append(daysLeft < 0
+                ? Math.abs(daysLeft) + " days overdue"
+                : daysLeft + " days left");
+        }
+        if (dueHours != null) {
+            double hoursLeft = Math.round((dueHours - currentTach) * 10.0) / 10.0;
+            String h = hoursLeft < 0
+                ? Math.abs(hoursLeft) + " hours overdue"
+                : hoursLeft + " hours left";
+            if (sb.length() > 0) sb.append('\n');
+            sb.append(h);
+        }
+        return sb.length() == 0 ? "N/A" : sb.toString();
+    }
+
+    // POST to add a custom description option directly (before any row uses it)
+    @PostMapping(value = "/addDescriptionOption", consumes = "application/json")
+    @ResponseBody
+    @Transactional
+    public ResponseEntity<Map<String, Object>> addDescriptionOption(
+            @RequestBody Map<String, String> body, Authentication authentication) {
+        User user = userRepository.findByUsername(authentication.getName());
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorBody("User not authenticated"));
+        }
+        String raw = body == null ? null : body.get("option");
+        if (raw == null) return ResponseEntity.badRequest().body(errorBody("Missing option"));
+        String trimmed = raw.trim();
+        if (trimmed.isEmpty()) return ResponseEntity.badRequest().body(errorBody("Option cannot be blank"));
+        if (DEFAULT_DESCRIPTION_OPTIONS.contains(trimmed.toLowerCase())) {
+            return ResponseEntity.badRequest().body(errorBody("That option already exists as a default"));
+        }
+        DescriptionOption existing = descriptionOptionRepository.findByUser(user).stream()
+            .filter(opt -> opt.getOption() != null && opt.getOption().equalsIgnoreCase(trimmed))
+            .findFirst().orElse(null);
+        DescriptionOption saved = (existing != null)
+            ? existing
+            : descriptionOptionRepository.save(new DescriptionOption(trimmed, user));
+        Map<String, Object> resp = new HashMap<>();
+        resp.put("status", "ok");
+        resp.put("id", saved.getId());
+        resp.put("option", saved.getOption());
+        return ResponseEntity.ok(resp);
+    }
+
     // DELETE flight log
     @DeleteMapping("/deleteflightlog/{id}")
     @ResponseBody
@@ -450,8 +663,8 @@ public ResponseEntity<Map<String, String>> updateHours(
             flightLogRepository.delete(log);
 
             List<FlightLog> remainingLogs = flightLogRepository.findByUser(user);
-            double newHobbs = calculateMergedHours(remainingLogs, true);
-            double newTach = calculateMergedHours(remainingLogs, false);
+            double newHobbs = computeDisplayedHours(user, remainingLogs, /*useHobbs=*/true);
+            double newTach  = computeDisplayedHours(user, remainingLogs, /*useHobbs=*/false);
             user.setHobbsHours(newHobbs);
             user.setTachHours(newTach);
             java.time.Instant flightNow = java.time.Instant.now();
@@ -471,43 +684,77 @@ public ResponseEntity<Map<String, String>> updateHours(
         }
     }
 
-    // Calculates total hours from all logs using interval merging to prevent double-counting
-    private double calculateMergedHours(List<FlightLog> logs, boolean useHobbs) {
-        List<double[]> intervals = new ArrayList<>();
+    /**
+     * Meter-snapshot recompute: the airframe meter only goes up.
+     *
+     * Displayed hours = max(manualBaseline, highest hobbsIn/tachIn across user's logs).
+     *
+     * If the baseline has never been written (legacy users), seed it from the
+     * user's current hobbsHours/tachHours so log activity can never silently
+     * lower the displayed value. After this call, the baseline is locked in
+     * and subsequent operations behave predictably.
+     */
+    private double computeDisplayedHours(User user, List<FlightLog> logs, boolean useHobbs) {
+        Double baselineBoxed = useHobbs ? user.getHobbsManualBaseline() : user.getTachManualBaseline();
+        if (baselineBoxed == null) {
+            // Seed once from the existing displayed value. Mutates the user;
+            // caller is expected to persist it.
+            double seed = useHobbs ? user.getHobbsHours() : user.getTachHours();
+            if (useHobbs) user.setHobbsManualBaseline(seed);
+            else          user.setTachManualBaseline(seed);
+            baselineBoxed = seed;
+        }
+        double baseline = baselineBoxed;
+
+        double maxFromLogs = 0.0;
+        boolean anyReading = false;
         for (FlightLog log : logs) {
-            Double a = useHobbs ? log.getHobbsOut() : log.getTachIn();
-            Double b = useHobbs ? log.getHobbsIn() : log.getTachOut();
-            if (a != null && b != null) {
-                double lo = Math.min(a, b);
-                double hi = Math.max(a, b);
-                if (hi > lo) intervals.add(new double[]{lo, hi});
+            Double reading = useHobbs ? log.getHobbsIn() : log.getTachIn();
+            if (reading != null) {
+                if (!anyReading || reading > maxFromLogs) maxFromLogs = reading;
+                anyReading = true;
             }
         }
-        if (intervals.isEmpty()) return 0.0;
-        intervals.sort(Comparator.comparingDouble(i -> i[0]));
-        double total = 0.0;
-        double[] current = intervals.get(0);
-        for (int i = 1; i < intervals.size(); i++) {
-            double[] interval = intervals.get(i);
-            if (interval[0] <= current[1]) {
-                current[1] = Math.max(current[1], interval[1]);
+        return anyReading ? Math.max(baseline, maxFromLogs) : baseline;
+    }
+
+    private static final java.util.Set<String> DEFAULT_DESCRIPTION_OPTIONS =
+        java.util.Set.of("inspect", "test", "replace", "overhaul");
+
+    // Drops blank entries and any custom option that duplicates a built-in
+    // (case-insensitive). Self-heals legacy bad rows on first dashboard load
+    // after this fix ships.
+    private List<DescriptionOption> cleanupAndLoadDescriptionOptions(User user) {
+        List<DescriptionOption> all = descriptionOptionRepository.findByUser(user);
+        java.util.Set<String> keptLower = new java.util.HashSet<>();
+        List<DescriptionOption> kept = new java.util.ArrayList<>();
+        List<DescriptionOption> toDelete = new java.util.ArrayList<>();
+        for (DescriptionOption opt : all) {
+            String value = opt.getOption();
+            String trimmed = value == null ? "" : value.trim();
+            String lower = trimmed.toLowerCase();
+            boolean isBlank = trimmed.isEmpty();
+            boolean isDefault = DEFAULT_DESCRIPTION_OPTIONS.contains(lower);
+            boolean isDup = !keptLower.add(lower);
+            if (isBlank || isDefault || isDup) {
+                toDelete.add(opt);
             } else {
-                total += current[1] - current[0];
-                current = interval;
+                kept.add(opt);
             }
         }
-        total += current[1] - current[0];
-        return total;
+        if (!toDelete.isEmpty()) descriptionOptionRepository.deleteAll(toDelete);
+        return kept;
     }
 
     private void saveCustomDescriptionOption(String description, User user) {
-        if (description != null) {
-            String[] defaults = {"inspect", "test", "replace", "overhaul"};
-            if (!java.util.Arrays.asList(defaults).contains(description)) {
-                if (!descriptionOptionRepository.findByUser(user).stream().anyMatch(opt -> opt.getOption().equals(description))) {
-                    descriptionOptionRepository.save(new DescriptionOption(description, user));
-                }
-            }
+        if (description == null) return;
+        String trimmed = description.trim();
+        if (trimmed.isEmpty()) return;
+        if (DEFAULT_DESCRIPTION_OPTIONS.contains(trimmed.toLowerCase())) return;
+        boolean alreadyExists = descriptionOptionRepository.findByUser(user).stream()
+            .anyMatch(opt -> opt.getOption() != null && opt.getOption().equalsIgnoreCase(trimmed));
+        if (!alreadyExists) {
+            descriptionOptionRepository.save(new DescriptionOption(trimmed, user));
         }
     }
 }

--- a/src/main/java/com/example/AviaryService/entity/DTO/TimelineUpdateDTO.java
+++ b/src/main/java/com/example/AviaryService/entity/DTO/TimelineUpdateDTO.java
@@ -7,6 +7,9 @@ public class TimelineUpdateDTO {
     private String lastDone;
     private String dueDate;
     private String timeLeft;
+    private Integer cycleCalendarValue;
+    private String cycleCalendarUnit;
+    private Double cycleHours;
 
     // Default constructor (required for Jackson deserialization)
     public TimelineUpdateDTO() {}
@@ -24,4 +27,13 @@ public class TimelineUpdateDTO {
     public void setDueDate(String dueDate) { this.dueDate = dueDate; }
     public String getTimeLeft() { return timeLeft; }
     public void setTimeLeft(String timeLeft) { this.timeLeft = timeLeft; }
+
+    public Integer getCycleCalendarValue() { return cycleCalendarValue; }
+    public void setCycleCalendarValue(Integer v) { this.cycleCalendarValue = v; }
+
+    public String getCycleCalendarUnit() { return cycleCalendarUnit; }
+    public void setCycleCalendarUnit(String u) { this.cycleCalendarUnit = u; }
+
+    public Double getCycleHours() { return cycleHours; }
+    public void setCycleHours(Double h) { this.cycleHours = h; }
 }

--- a/src/main/java/com/example/AviaryService/entity/ServiceTimeline.java
+++ b/src/main/java/com/example/AviaryService/entity/ServiceTimeline.java
@@ -34,6 +34,19 @@ public class ServiceTimeline {
     @Column
     private Integer timelineOrder;
 
+    // Structured cycle drives the "Complete Maintenance" button.
+    // Nullable: a row may have a calendar cycle, an hours cycle, both, or
+    // neither (legacy rows where only the free-text `cycle` is filled).
+    @Column
+    private Integer cycleCalendarValue;
+
+    // Stored as the enum name: "DAYS" | "MONTHS" | "YEARS".
+    @Column
+    private String cycleCalendarUnit;
+
+    @Column
+    private Double cycleHours;
+
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     @JsonBackReference
@@ -83,4 +96,13 @@ public class ServiceTimeline {
 
     public User getUser() { return user; }
     public void setUser(User user) { this.user = user; }
+
+    public Integer getCycleCalendarValue() { return cycleCalendarValue; }
+    public void setCycleCalendarValue(Integer cycleCalendarValue) { this.cycleCalendarValue = cycleCalendarValue; }
+
+    public String getCycleCalendarUnit() { return cycleCalendarUnit; }
+    public void setCycleCalendarUnit(String cycleCalendarUnit) { this.cycleCalendarUnit = cycleCalendarUnit; }
+
+    public Double getCycleHours() { return cycleHours; }
+    public void setCycleHours(Double cycleHours) { this.cycleHours = cycleHours; }
 }

--- a/src/main/java/com/example/AviaryService/entity/User.java
+++ b/src/main/java/com/example/AviaryService/entity/User.java
@@ -55,6 +55,15 @@ public class User {
     @Column
     private String tachUpdatedSource;
 
+    // Manual "floor" for the airframe meter. Any manual edit on /updateHours
+    // writes this column too; log-book activity can only raise the displayed
+    // value above this floor, never below it. See computeDisplayedHours().
+    @Column
+    private Double hobbsManualBaseline;
+
+    @Column
+    private Double tachManualBaseline;
+
     public User(){
 
     }
@@ -169,4 +178,11 @@ public class User {
 
     public String getTachUpdatedSource() { return tachUpdatedSource; }
     public void setTachUpdatedSource(String tachUpdatedSource) { this.tachUpdatedSource = tachUpdatedSource; }
+
+    // Nullable on purpose: callers must distinguish "never set" from "set to 0".
+    public Double getHobbsManualBaseline() { return hobbsManualBaseline; }
+    public void setHobbsManualBaseline(Double hobbsManualBaseline) { this.hobbsManualBaseline = hobbsManualBaseline; }
+
+    public Double getTachManualBaseline() { return tachManualBaseline; }
+    public void setTachManualBaseline(Double tachManualBaseline) { this.tachManualBaseline = tachManualBaseline; }
 }

--- a/src/main/resources/static/css/dashboardstyle.css
+++ b/src/main/resources/static/css/dashboardstyle.css
@@ -304,7 +304,7 @@ body {
 /* ── Service timeline table ── */
 table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) {
   width: 100%;
-  table-layout: fixed;
+  table-layout: auto;
   border-collapse: collapse;
   border-radius: var(--radius);
   box-shadow: var(--shadow-sm);
@@ -312,15 +312,28 @@ table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) {
   margin: 0;
 }
 
-/* Column widths — proportional so table always fits 100% width */
+/* Column widths — auto layout. Percentages are preferred widths; the
+   browser honors them when content fits and lets columns grow only if
+   minimum content demands it. Item matches Description (free-text columns
+   shouldn't dominate). Last Done / Due Date are the widest data columns
+   AND carry a min-width floor so their date (mm/dd/yyyy) + hours inputs can
+   never collapse small enough to spill out of their cell and hide behind a
+   neighbor — on a too-narrow window the table grows past the viewport
+   (page scrolls) instead. Time Left has no width hint so it sizes to its
+   content (header "TIME LEFT" or longest data line). */
 table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(1) { width: 28px; }
-table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(2) { width: 22%; }
-table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(3) { width: 14%; }
-table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(4) { width: 11%; }
-table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(5) { width: 14%; }
-table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(6) { width: 14%; }
-table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(7) { width: 11%; }
-table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(8) { width: 36px; }
+table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(2) { width: 18%; }
+table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(3) { width: 18%; }
+table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(4) { width: 14%; }
+table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(5) { width: 20%; min-width: 150px; }
+table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(6) { width: 20%; min-width: 150px; }
+/* width:1% + nowrap = shrink-to-content. The 1% preferred width is below the
+   column's min-content (the "TIME LEFT" header / widest data line), so the
+   column collapses to exactly its content; the leftover table width then
+   flows into the percentage columns above instead of padding Time Left. */
+table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(7) { width: 1%; white-space: nowrap; }
+table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(8) { width: 4%; min-width: 36px; }
+table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) th:nth-child(9) { width: 4%; min-width: 36px; }
 
 /* Round the header corners since overflow:visible no longer clips them */
 
@@ -340,7 +353,40 @@ th {
 td {
   padding: 8px 10px;
   text-align: left;
+  /* Continuous-grid redesign: every cell's content is vertically CENTERED
+     and the inner controls are borderless, so a short field reads as a
+     filled grid cell (no floating box, no dead space above/below) even when
+     the row is made tall by the two-line Cycle column. */
   vertical-align: middle;
+}
+
+/* Continuous-grid hairlines — the cell border IS the field's outline, so no
+   control needs its own box. */
+table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) td {
+  border-top: 1px solid var(--border);
+}
+table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) td + td {
+  border-left: 1px solid var(--border);
+}
+
+/* Icon cells (grip handle, complete/update button, delete trash, Add button)
+   override the top-alignment above — their content is a small icon/button
+   that should sit centered vertically in the row regardless of how tall the
+   row got from the Cycle column. */
+td.grip-cell,
+td.complete-cell,
+td.delete-cell,
+td.add-cell {
+  vertical-align: middle;
+  text-align: center;
+}
+.grip-icon,
+.complete-btn,
+.delete-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto;
 }
 
 .grip-icon {
@@ -374,6 +420,8 @@ td {
   text-align: center;
 }
 .title-row .title-cell:hover { background: var(--primary-dark); cursor: pointer; }
+/* No grid hairlines inside the solid green title bar */
+.title-row td { border-color: transparent; }
 
 /* Add row */
 .add-row td { background: var(--primary-light); border-top: 2px dashed var(--primary); }
@@ -386,20 +434,61 @@ td {
   background: var(--primary-light); 
   border-top: 2px dashed var(--primary); }
 
-/* Add row inputs — always visible so user knows where to type */
+/* Add-row Item is a clean bordered input box (the place you type a new item),
+   no longer a skinny sliver — sized like a proper field. */
 .add-row td textarea {
   border: 1px solid var(--border) !important;
   background: var(--surface) !important;
+  border-radius: 6px;
+  min-height: 32px;
+  padding: 6px 10px;
 }
 .add-row td textarea::placeholder { display: inline; color: var(--text-muted); }
-.add-row .selected-option {
-  border: 1px solid var(--border) !important;
-  background: var(--surface) !important;
+
+/* Description dropdown in add-row: put the bordered box on the wrapper
+   (.custom-dropdown) and lay it out as flex, so the chevron sits INSIDE
+   the same visible box as the selected text — matching the
+   .input-with-dropdown pattern used by the Last Done / Due Date columns
+   below. (Previously the border was on .selected-option, leaving the
+   chevron outside the box — visually inconsistent.) */
+.add-row .custom-dropdown {
+  border: 1px solid transparent;   /* borderless to match the grid; flex keeps chevron inside */
+  background: transparent;
   border-radius: 4px;
+  padding: 2px 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  position: relative;
+  min-height: 26px;
 }
-.add-row .input-with-dropdown {
-  border: 1px solid var(--border);
+.add-row .custom-dropdown .selected-option {
+  border: none !important;
+  background: transparent !important;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.add-row .custom-dropdown .trigger-dropdown {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+.add-row .custom-dropdown .dropdown-options {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
   background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  box-shadow: var(--shadow-sm);
+  z-index: 100;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.add-row .input-with-dropdown {
+  border: 1px solid transparent;   /* borderless to match the grid */
+  background: transparent;
   border-radius: 4px;
   padding: 2px 4px;
 }
@@ -417,7 +506,10 @@ td input:focus {
 
 td textarea {
   width: 100%;
-  min-height: 28px;
+  /* One line of 13px text + 4px top/bottom padding ≈ 22px. Lets the
+     textarea start at one-line height; JS auto-grow expands it as the
+     user types (see setTextareaMinHeight in dashboard.js). */
+  min-height: 22px;
   max-height: 120px;
   min-width: 0;
   box-sizing: border-box;
@@ -428,10 +520,11 @@ td textarea {
   overflow-y: auto;
   font-family: inherit;
   font-size: 13px;
+  line-height: 1.3;
   color: var(--text);
   background: transparent;
 }
-td textarea:hover { border-color: var(--border); }
+td textarea:hover { background: var(--row-hover); }
 td textarea:focus { outline: 2px solid var(--primary); background: var(--surface); }
 
 .title-input {
@@ -446,11 +539,33 @@ td textarea:focus { outline: 2px solid var(--primary); background: var(--surface
 }
 
 /* Add / delete cells */
-.add-button {
+/* The Add cell hosts a <form> wrapping the submit button. Cell has padding
+   so the button has visible breathing room from the cell edges (looks
+   "centered" instead of edge-to-edge). The form fills the inner space and
+   the button fills the form, so the button still scales with screen size. */
+.add-cell {
+  padding: 10px 14px;   /* generous breathing room so the Add button never touches the cell border */
+}
+.add-cell form {
+  display: block;
   width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+.add-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-height: 36px;
   padding: 8px 12px;
+  margin: 0;
   background: var(--accent);
   color: #fff;
+  box-sizing: border-box;
+  white-space: nowrap;
 }
 .add-button:hover { background: var(--accent-hover); }
 
@@ -461,6 +576,82 @@ td textarea:focus { outline: 2px solid var(--primary); background: var(--surface
 .delete-header, .delete-cell { text-align: center; }
 .delete-icon { cursor: pointer; color: #c0ccc5; font-size: 15px; }
 .delete-icon:hover { color: var(--accent); }
+
+.complete-header, .complete-cell { text-align: center; }
+.complete-btn {
+  background: transparent; border: none; cursor: pointer;
+  color: #c0ccc5; font-size: 15px; padding: 4px;
+}
+.complete-btn:hover { color: var(--accent); }
+.complete-btn[disabled] { opacity: 0.35; cursor: not-allowed; }
+.complete-btn-label { display: none; }  /* desktop: icon-only */
+/* The card collapse arrow is a mobile-card affordance only — hidden on desktop
+   (it is shown again inside the mobile media query). !important beats the
+   runtime FontAwesome <style> that sets .svg-inline--fa { display:inline-block }. */
+.card-caret { display: none !important; }
+
+/* Cycle cell fills the whole grid cell as two hairline-split halves, so the
+   row's height is defined here and every neighbour cell centers to match it
+   with no dead space. The cell's own padding is removed so the hairline and
+   halves span edge to edge. */
+table:not(.aircraft-info-table):not(.hours-table):not(.logbook-table) td:has(> .cycle-structured) {
+  padding: 0;
+}
+.cycle-structured {
+  display: flex; flex-direction: column; gap: 0;
+  min-width: 0; max-width: 100%;
+  height: 100%;
+}
+.cycle-row {
+  display: flex; align-items: center; gap: 4px;
+  min-width: 0;
+  flex: 1;
+  flex-wrap: nowrap;
+  padding: 6px 10px;
+  min-height: 33px;            /* gives saved rows real height so Cycle breathes */
+  border-bottom: 1px solid var(--border);
+}
+.cycle-row:last-child { border-bottom: none; }
+.cycle-row > * { min-width: 0; }
+/* Number input — fits values like "100.0". Hide the native spinner arrows
+   so the field's whole width is usable for digits. */
+.cycle-num {
+  flex: 0 1 56px;
+  width: 56px;
+  min-width: 44px;
+  padding: 2px 4px;
+  font-size: 12px;
+  box-sizing: border-box;
+  border: 1px solid transparent;   /* borderless: grid cell is the outline */
+  background: transparent;
+  border-radius: 4px;
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+.cycle-num::-webkit-outer-spin-button,
+.cycle-num::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+/* Unit dropdown — no min-width floor so it always fits its parent. When the
+   column gets too narrow, the browser truncates the displayed option text. */
+.cycle-unit {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 100%;
+  max-width: 110px;
+  padding: 2px 4px;
+  font-size: 12px;
+  box-sizing: border-box;
+  border: 1px solid transparent;   /* borderless to match the grid */
+  background: transparent;
+  border-radius: 4px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.cycle-unit:focus { outline: 2px solid var(--primary); }
+/* "hrs" suffix sits flush right inside the cell, never spilling out */
+.cycle-unit-label { font-size: 12px; color: #5a6b66; flex-shrink: 0; margin-left: auto; }
 
 /* ── Dropdowns ── */
 .custom-dropdown {
@@ -484,7 +675,7 @@ td textarea:focus { outline: 2px solid var(--primary); background: var(--surface
   color: var(--text);
   border-radius: 4px;
 }
-.selected-option:hover { border-color: var(--border); }
+.selected-option:hover { background: var(--row-hover); }
 
 .dropdown-options {
   display: none;
@@ -561,29 +752,65 @@ td textarea:focus { outline: 2px solid var(--primary); background: var(--surface
 }
 .remove-option-btn:hover { color: var(--accent); }
 
-/* Date/type dropdown */
+/* Date/type dropdown.
+   Grid layout: left column holds the date + hours inputs stacked vertically,
+   right column holds the chevron (vertically centered across the stack).
+   The inputs are ordered with CSS `order` so the calendar (date) input is
+   ALWAYS on top and hours is ALWAYS on the bottom, regardless of the order
+   the user added them in. Removing one leaves the other in its correct slot
+   automatically — no JS ordering logic needed (value reads are type-based,
+   not position-based). */
 .input-with-dropdown {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 1fr auto;
   position: relative;
   align-items: center;
+  column-gap: 2px;
+  row-gap: 4px;
   width: 100%;
   min-width: 0;
-  gap: 2px;
   /* no z-index — open panel's own z-index works globally */
 }
 
 .input-with-dropdown input.extra-input {
-  flex: 1 1 80px;
+  grid-column: 1;
+  width: 100%;
   min-width: 0;
   box-sizing: border-box;
   padding: 4px 6px;
-  border: 1px solid var(--border);
+  border: 1px solid transparent;  /* borderless: the grid cell is the outline */
   border-radius: 4px;
   font-family: inherit;
   font-size: 13px;
   color: var(--text);
   background: transparent;
+}
+
+/* Calendar always above hours, independent of DOM/add order.
+   min-width floors keep each field wide enough to stay fully readable — a
+   native date field needs room for "mm/dd/yyyy" + its picker icon — so the
+   column can't shrink them small enough to overflow the cell and hide. */
+.input-with-dropdown input[type="date"].extra-input { order: 1; min-width: 118px; }
+.input-with-dropdown input[type="text"].extra-input { order: 2; min-width: 72px; }
+
+/* Empty Last Done / Due Date cell: show a hint that fills the cell, so there's
+   no gap before a calendar/hours value is added. Hidden once any input exists. */
+.input-with-dropdown:not(:has(input.extra-input))::before {
+  content: "Add date / hrs";
+  grid-column: 1;
+  align-self: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+/* Chevron lives in the right column, spanning and centered across the
+   stacked inputs (matches its current right-of-the-input placement). */
+.input-with-dropdown .trigger-dropdown {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  align-self: center;
+  margin-left: 0;
 }
 
 .input-with-dropdown input.extra-input:focus {
@@ -645,30 +872,41 @@ td textarea:focus { outline: 2px solid var(--primary); background: var(--surface
 }
 
 /* Row type selector */
+/* Item/Title picker — one connected segmented control with EQUAL-width
+   segments (no longer two differently sized pills). */
 .row-type-selector {
   display: flex;
-  gap: 6px;
-  margin-bottom: 6px;
+  gap: 0;
+  margin-bottom: 8px;
+  width: max-content;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  overflow: hidden;
+  background: var(--surface);
 }
 
 .row-type-option {
   cursor: pointer;
-  padding: 3px 10px;
+  flex: 1;
+  min-width: 58px;
+  text-align: center;
+  padding: 5px 0;
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 12px;
   font-size: 12px;
   font-weight: 500;
   color: var(--text-muted);
 }
+.row-type-option + .row-type-option { border-left: 1px solid var(--border); }
 .row-type-option.selected {
   background: var(--accent);
   color: #fff;
-  border-color: var(--accent);
 }
 
-/* Time left */
-.time-left { white-space: pre-line; font-size: 12px; }
+/* Time left — `pre` (not pre-line) so each line breaks only at its explicit
+   \n and never mid-line. In the auto-layout table this makes the column grow
+   to fit the longest data line rather than wrapping, so the column is exactly
+   as wide as its content (header or data, whichever is wider). */
+.time-left { white-space: pre; font-size: 12px; }
 
 /* ── Logbook table ── */
 .logbook-table {
@@ -747,8 +985,13 @@ textarea::placeholder { display: none; }
 
 .add-row.title-mode td:nth-child(n+3):nth-child(-n+7) * { visibility: hidden; }
 
-/* ── Mobile (≤768px) ── */
-@media screen and (max-width: 768px) {
+/* ── Mobile / narrow (≤960px) ──
+   The service-timeline table has a hard min-content width of ~903px (the Last
+   Done / Due Date columns floor at 150px so the date inputs never clip). Below
+   that the table would grow past the viewport and the whole page would scroll
+   sideways. So we switch to the stacked card layout at ≤960px (comfortably
+   above 903) — the cards always fit, so the timeline never overflows. ── */
+@media screen and (max-width: 960px) {
   .header { padding: 16px 24px 0; }
   /*.main   { padding: 12px; }*/
   .tabs   { padding: 16px 12px 0; }
@@ -795,57 +1038,364 @@ textarea::placeholder { display: none; }
     padding: 10px;
   }
 
+  /* Title bar: a clean solid-green card with the title centered and larger;
+     the trash sits pinned to the right. No stray cell hairlines (the global
+     td + td border-left would otherwise show as white marks on the green). */
   .sortable tr.title-row {
+    position: relative;
+    display: block;
     background: var(--primary);
-    font-weight: 700;
+    padding: 14px 46px;
+    border-radius: var(--radius);
     text-align: center;
-    padding: 12px;
-    display: flex;
-    justify-content: space-between;
   }
-  .sortable tr.title-row td { display: block; border: none; color: #fff; }
+  .sortable tr.title-row td {
+    display: block;
+    border: none !important;
+    background: transparent;
+    color: #fff;
+    padding: 0;
+  }
+  .sortable tr.title-row td.grip-cell,
+  .sortable tr.title-row td.complete-cell { display: none; }
+  .sortable tr.title-row td.title-cell {
+    text-align: center;
+    font-size: 17px;
+    font-weight: 700;
+    line-height: 1.3;
+    color: #fff;
+  }
+  .sortable tr.title-row td.delete-cell {
+    position: absolute;
+    top: 50%;
+    right: 12px;
+    transform: translateY(-50%);
+    padding: 0;
+  }
 
+  /* ── Service-timeline cards (mobile): flat, borderless fields that match the
+        desktop look, laid out 1 / 2-2 / 1 like the log book:
+          row 1  Item       (full-width headline, tap to collapse)
+          row 2  Description | Last Done
+          row 3  Cycle       | Due Date
+          row 4  Time Left   (full width)
+          row 5  Complete    (full-width action)
+          row 6  Delete
+        Cards are expanded by default; tapping the Item headline collapses the
+        card down to just its name (see .collapsed below + dashboard.js). ── */
+  .sortable tr:not(.title-row):not(.add-row) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0;                         /* cells tile edge-to-edge; borders are the separators */
+    align-items: stretch;
+    padding: 0;
+    overflow: hidden;               /* clip the cell gridlines to the card's rounded corners */
+  }
   .sortable tr:not(.title-row):not(.add-row) td:not(.grip-cell) {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 6px 8px;
+    display: block;
+    padding: 10px 14px;
     border: none;
-    border-bottom: 1px solid var(--border);
-    background: var(--surface);
+    border-bottom: 1px solid var(--border);   /* row separator */
+    background: transparent;
   }
-
-  /* No border under the last field (trash icon) in a card */
-  .sortable tr:not(.title-row):not(.add-row) td.delete-cell {
-    border-bottom: none;
-    justify-content: center;
-    padding-top: 10px;
+  /* Vertical divider between the left and right columns (rows 2 & 3). */
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Description"],
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Cycle"] {
+    border-right: 1px solid var(--border);
   }
+  /* No trailing separators below the action rows. */
+  .sortable tr:not(.title-row):not(.add-row) td.complete-cell,
+  .sortable tr:not(.title-row):not(.add-row) td.delete-cell { border-bottom: none; }
+  /* Explicit 1 / 2-2 / 1 placement — deterministic regardless of DOM order
+     or grid auto-flow quirks. */
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Item"]        { grid-column: 1 / -1; grid-row: 1; }
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Description"] { grid-column: 1;      grid-row: 2; }
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Last Done"]   { grid-column: 2;      grid-row: 2; }
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Cycle"]       { grid-column: 1;      grid-row: 3; }
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Due Date"]    { grid-column: 2;      grid-row: 3; }
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Time Left"]   { grid-column: 1 / -1; grid-row: 4; }
+  .sortable tr:not(.title-row):not(.add-row) td.complete-cell             { grid-column: 1 / -1; grid-row: 5; }
+  .sortable tr:not(.title-row):not(.add-row) td.delete-cell               { grid-column: 1 / -1; grid-row: 6; }
+  /* Drag handle is a desktop affordance — hide inside cards */
+  .sortable tr:not(.add-row) td.grip-cell { display: none; }
 
-  .sortable tr:not(.title-row):not(.add-row) td::before {
+  /* Collapsed card → show only the Item headline (tap to re-expand).
+     The :not()s match the base rules' specificity so these overrides win. */
+  .sortable tr.collapsed td:not([data-label="Item"]):not(.grip-cell) { display: none; }
+  .sortable tr.collapsed:not(.title-row):not(.add-row) td[data-label="Item"] { border-bottom: none; }
+
+  /* Field labels: small caps above each control */
+  .sortable tr:not(.title-row):not(.add-row) td:not(.grip-cell)::before {
     content: attr(data-label);
+    display: block;
+    margin-bottom: 5px;
     font-weight: 600;
     font-size: 11px;
     text-transform: uppercase;
     color: var(--text-muted);
-    flex: 1;
   }
 
-  .sortable td textarea, .sortable td .selected-option,
-  .sortable td .input-with-dropdown { width: 100%; }
+  /* Item = bold card headline (no label) + a big FA collapse arrow on the
+     right (the same chevron the fields use, just larger). */
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Item"] {
+    position: relative;
+    padding-right: 44px;
+    cursor: pointer;
+  }
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Item"]::before { display: none; }
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Item"] .card-caret {
+    display: block !important;
+    position: absolute;
+    top: 50%;
+    right: 12px;
+    transform: translateY(-50%);
+    color: var(--text-muted);
+    font-size: 20px;               /* bigger than the 15px field chevrons */
+  }
+  .sortable tr.collapsed:not(.title-row):not(.add-row) td[data-label="Item"] .card-caret {
+    transform: translateY(-50%) rotate(-90deg);
+  }
+  .sortable td textarea {
+    width: 100%;
+    min-height: 32px;
+    max-height: 160px;
+    border: none;
+    background: transparent;
+    padding: 0 0 2px;
+    font-size: 19px;
+    font-weight: 700;
+    color: var(--text);
+  }
+
+  /* Description = flat, borderless control (matches the desktop cell). */
+  .sortable td .custom-dropdown {
+    width: 100%;
+    align-items: center;
+    padding: 0;
+    border: none;
+    background: transparent;
+  }
+  .sortable td .custom-dropdown .selected-option {
+    width: 100%;
+    min-height: 32px;
+    display: flex;
+    align-items: center;
+    font-size: 15px;
+    border: none;
+    padding: 4px 0;
+  }
+  .custom-dropdown .trigger-dropdown,
+  .input-with-dropdown .trigger-dropdown { min-width: 32px; min-height: 32px; font-size: 15px; }
+
+  /* Cycle = flat, borderless; keep the desktop hairline between the two rows. */
+  .sortable tr:not(.title-row):not(.add-row) td .cycle-structured {
+    width: 100%;
+    height: auto;                 /* override desktop height:100% — its %-height is
+                                     ambiguous in the grid and lets the 2nd row spill
+                                     out of the cell (over Time Left). */
+    align-items: stretch;
+    border: none;
+    background: transparent;
+    overflow: visible;
+  }
+  .sortable tr:not(.title-row):not(.add-row) td .cycle-row {
+    flex: 0 0 auto;               /* size to content; don't flex-stretch */
+    justify-content: flex-start;
+    gap: 8px;
+    padding: 6px 0;
+    min-height: 38px;
+  }
+  .sortable td .cycle-num {
+    flex: 0 0 64px;
+    width: 64px;
+    max-width: none;
+    text-align: left;
+    font-size: 15px;
+    border: none;
+    background: transparent;
+    padding: 4px 0;
+  }
+  /* Cycle "unit" dropdown: swap the native select arrow for the same FA
+     chevron the other fields use. The chevron lives directly in this rule (and
+     in the .add-row one) because a separate, lower-specificity .cycle-unit rule
+     would be clobbered by the `background: transparent` shorthand here. */
+  .sortable td .cycle-unit {
+    flex: 1 1 auto;
+    width: auto;
+    max-width: none;
+    min-width: 0;
+    min-height: 32px;
+    font-size: 15px;
+    border: none;
+    padding: 4px 30px 4px 0;
+    appearance: none;
+    -webkit-appearance: none;
+    background-color: transparent;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%235E7A6A' d='M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 14px;
+  }
+  .sortable td .cycle-unit-label { font-size: 15px; margin-left: 4px; }
+
+  /* The global `td:has(> .cycle-structured) { padding: 0 }` desktop rule
+     outranks the per-cell mobile padding, so the Cycle cell would sit flush.
+     Restore the same padding the other cells get (saved + add rows). */
+  .sortable tr:not(.title-row):not(.add-row) td[data-label="Cycle"],
+  .add-row td[data-label="Cycle"] { padding: 10px 14px !important; }
+
+  /* Add-row: cycle structured inputs stack vertically with sane widths */
+  .add-row .cycle-structured { width: 100%; max-width: 100%; }
+  .add-row .cycle-num { max-width: 90px; }
+  .add-row .cycle-unit { max-width: 110px; }
+
+  /* Last Done / Due Date = flat, borderless date + hrs + chevron. */
+  .sortable td .input-with-dropdown {
+    width: 100%;
+    border: none;
+    background: transparent;
+    padding: 0;
+    column-gap: 4px;
+    row-gap: 4px;
+  }
+  .sortable td .input-with-dropdown input.extra-input {
+    min-height: 34px;
+    font-size: 15px;
+    padding: 4px 0;
+  }
+  /* In the half-width right column a native date field must be free to shrink
+     so it (and its chevron) never overflow the cell. */
+  .sortable td .input-with-dropdown input[type="date"].extra-input { min-width: 0; }
+  .sortable td .input-with-dropdown:not(:has(input.extra-input))::before {
+    font-size: 14px;
+    padding: 8px 0;
+  }
+
+  /* Time Left = plain readout, horizontally centered (no pill). */
+  .sortable td .time-left,
+  .add-row td .time-left {
+    font-size: 15px;
+    text-align: center;
+    font-weight: 600;
+    color: var(--primary-dark);
+    background: transparent;
+    border-radius: 0;
+    padding: 4px 0;
+    white-space: pre;
+  }
+
+  /* Complete = full-width primary (pink) action */
+  .sortable tr:not(.title-row):not(.add-row) td.complete-cell::before { display: none; }
+  .sortable tr:not(.title-row):not(.add-row) td.complete-cell { padding-top: 2px; }
+  .complete-btn {
+    width: 100%;
+    min-height: 50px;
+    padding: 12px 14px;
+    font-size: 16px;
+    color: #fff;
+    background: var(--accent);
+    border: none;
+    border-radius: var(--radius);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+  .complete-btn:hover { background: var(--accent-hover); color: #fff; }
+  .complete-btn[disabled] { opacity: 0.4; }
+  .complete-btn-label { display: inline; }
+
+  /* Delete = centered trash, comfortable tap target */
+  .sortable tr:not(.title-row):not(.add-row) td.delete-cell::before { display: none; }
+  .sortable tr:not(.title-row):not(.add-row) td.delete-cell { text-align: center; padding-top: 2px; }
+  .sortable td.delete-cell .delete-icon { font-size: 20px; padding: 8px; display: inline-block; }
 
   .grip-column { display: none; }
   .custom-dropdown, .input-with-dropdown { width: 100%; }
   .dropdown-options, .type-dropdown { width: 100%; max-height: 150px; }
 
+  /* Add row: same 1 / 2-2 / 1 grid + flat fields + separating gridlines as the
+     saved cards, but kept visually distinct (green tint + dashed edge) as the
+     "add new" zone. */
   .add-row {
-    display: block; padding: 12px; margin: 0;
-    border: 1px solid var(--border); border-radius: var(--radius);
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0;
+    padding: 0;
+    margin: 0;
+    border: 1px dashed var(--primary);
+    border-radius: var(--radius);
     background: var(--primary-light);
+    overflow: hidden;
   }
-  .add-row td { display: block; border: none; padding: 6px 8px; background: var(--primary-light); }
-  .add-row td::before { content: attr(data-label); font-weight: 600; font-size: 11px; display: block; margin-bottom: 4px; color: var(--text-muted); }
+  .add-row td {
+    display: block;
+    border: none;
+    border-bottom: 1px solid var(--border);
+    padding: 10px 14px;
+    background: transparent;
+  }
+  .add-row td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    display: block;
+    margin-bottom: 4px;
+    color: var(--text-muted);
+  }
   .add-row td.grip-column { display: none; }
+  /* Placement mirrors the saved card. */
+  .add-row td[data-label="Item"]        { grid-column: 1 / -1; grid-row: 1; }
+  .add-row td[data-label="Description"] { grid-column: 1;      grid-row: 2; border-right: 1px solid var(--border); }
+  .add-row td[data-label="Last Done"]   { grid-column: 2;      grid-row: 2; }
+  .add-row td[data-label="Cycle"]       { grid-column: 1;      grid-row: 3; border-right: 1px solid var(--border); }
+  .add-row td[data-label="Due Date"]    { grid-column: 2;      grid-row: 3; }
+  .add-row td[data-label="Time Left"]   { grid-column: 1 / -1; grid-row: 4; }
+  .add-row td.add-cell                  { grid-column: 1 / -1; grid-row: 5; border-bottom: none; }
+  .add-row td[data-label="Item"]::before,
+  .add-row td.add-cell::before { display: none; }
+
+  /* Flat add-row controls (match the saved card; gridlines give the structure). */
+  .add-row td textarea { border: none; background: transparent; }
+  /* The item name is centered when adding, matching the centered Time Left. */
+  .add-row td[data-label="Item"] textarea,
+  .add-row td[data-label="Item"] input.title-input { text-align: center; }
+  .add-row .custom-dropdown {
+    width: 100%; align-items: center; padding: 0; border: none; background: transparent;
+  }
+  .add-row .custom-dropdown .selected-option {
+    width: 100%; min-height: 32px; display: flex; align-items: center; font-size: 15px; border: none; padding: 4px 0;
+  }
+  .add-row .input-with-dropdown {
+    width: 100%; border: none; background: transparent; padding: 0; min-height: 32px;
+  }
+  .add-row .cycle-structured {
+    width: 100%; max-width: 100%; height: auto; align-items: stretch; border: none; background: transparent; overflow: visible;
+  }
+  .add-row .cycle-row { flex: 0 0 auto; justify-content: flex-start; gap: 8px; padding: 6px 0; min-height: 38px; }
+  .add-row .cycle-num {
+    flex: 0 0 64px; width: 64px; max-width: none; text-align: left; font-size: 15px; border: none; background: transparent; padding: 4px 0;
+  }
+  .add-row .cycle-unit {
+    flex: 1 1 auto; width: auto; max-width: none; min-width: 0; min-height: 32px; font-size: 15px; border: none; padding: 4px 30px 4px 0;
+    appearance: none; -webkit-appearance: none;
+    background-color: transparent;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%235E7A6A' d='M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 14px;
+  }
+  .add-row .cycle-unit-label { margin-left: 4px; font-size: 15px; }
+
+  /* Adding a Title: the item-only fields are irrelevant, so REMOVE them
+     (display:none reclaims the space) instead of leaving empty boxes. The
+     add card collapses to just the Item/Title picker + title input + Add. */
+  .add-row.title-mode td[data-label="Description"],
+  .add-row.title-mode td[data-label="Cycle"],
+  .add-row.title-mode td[data-label="Last Done"],
+  .add-row.title-mode td[data-label="Due Date"],
+  .add-row.title-mode td[data-label="Time Left"] { display: none; }
 
   #export-excel, #print-dashboard, .add-button { width: 100%; margin: 8px 0; padding: 12px; }
 
@@ -853,43 +1403,59 @@ textarea::placeholder { display: none; }
   .logbook-table thead { display: none; }
   .logbook-table tbody#logbook-body { display: flex; flex-direction: column; gap: 8px; margin: 0; }
 
+  /* Option C: each log = 2-col grid (From|To, Hobbs Out|In, Tach Out|In) */
   .logbook-table tr.log-row,
   .logbook-table tr.add-log-row {
-    display: block;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    padding: 14px;
     border: 1px solid var(--border);
     border-radius: var(--radius);
     box-shadow: var(--shadow-sm);
-    padding: 10px;
+    background: var(--primary-light);
     margin-bottom: 4px;
   }
-  .logbook-table tr.log-row,
-  .logbook-table tr.add-log-row { background: var(--primary-light); }
 
   .logbook-table td {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 6px 8px;
+    display: block;
+    padding: 0;
     border: none;
-    border-bottom: 1px solid var(--border);
     background: transparent;
   }
-  .logbook-table td::before { 
-    content: attr(data-label); 
-    font-weight: 600; 
-    font-size: 11px; 
-    text-transform: uppercase; 
-    color: var(--text-muted); 
-    flex: 1; 
-    margin-right: 8px; 
+  .logbook-table td::before {
+    content: attr(data-label);
+    display: block;
+    margin-bottom: 5px;
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    color: var(--text-muted);
     text-align: left;
   }
 
-  .logbook-table td > *:not(.add-log-button) { flex: 2; text-align: right; }
-  .logbook-table input { width: 100%; padding: 8px; box-sizing: border-box; }
+  .logbook-table input {
+    width: 100%;
+    min-height: 44px;
+    font-size: 15px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    padding: 10px 12px;
+    box-sizing: border-box;
+  }
 
-  .logbook-table .delete-cell,
-  .logbook-table .add-cell { display: block !important; text-align: center; border-bottom: none; padding-top: 10px; }
+  .logbook-table td.delete-cell,
+  .logbook-table td.add-cell {
+    grid-column: 1 / -1;
+    text-align: center;
+    border-bottom: none;
+    padding-top: 4px;
+  }
+  .logbook-table td.delete-cell::before,
+  .logbook-table td.add-cell::before { display: none; }
+  .logbook-table .delete-log-icon { font-size: 20px; padding: 8px; background: none; border: none; cursor: pointer; }
+  .logbook-table .add-log-button { width: 100%; }
 
   .logbook-table .print-only { display: none; }
 
@@ -897,8 +1463,8 @@ textarea::placeholder { display: none; }
   .my-hours { width: 100%; margin: 8px 0; }
 }
 
-/* ── Tablet (769–1024px) ── */
-@media screen and (min-width: 769px) and (max-width: 1024px) {
+/* ── Tablet (961–1024px) — desktop table shows here (it fits above ~903px) ── */
+@media screen and (min-width: 961px) and (max-width: 1024px) {
   table { font-size: 13px; }
   th, td { padding: 7px 8px; }
   .grip-column { min-width: 20px; }

--- a/src/main/resources/static/js/dashboard.js
+++ b/src/main/resources/static/js/dashboard.js
@@ -26,7 +26,7 @@ function showToast(message, type = 'info') {
     }, 3500);
 }
 
-function showConfirm(message) {
+function showConfirm(message, confirmLabel = 'Confirm') {
     return new Promise(resolve => {
         const overlay = document.createElement('div');
         overlay.className = 'confirm-overlay';
@@ -35,9 +35,10 @@ function showConfirm(message) {
             '  <div class="confirm-message"></div>' +
             '  <div class="confirm-actions">' +
             '    <button type="button" class="confirm-btn cancel">Cancel</button>' +
-            '    <button type="button" class="confirm-btn ok">Delete</button>' +
+            '    <button type="button" class="confirm-btn ok"></button>' +
             '  </div>' +
             '</div>';
+        overlay.querySelector('.confirm-btn.ok').textContent = confirmLabel;
         overlay.querySelector('.confirm-message').textContent = message;
         document.body.appendChild(overlay);
         requestAnimationFrame(() => overlay.classList.add('show'));
@@ -115,11 +116,29 @@ function autoSave(input) {
     const id = row.getAttribute('data-id'); //grab 'data-id' of row
     //const status = row.querySelector('.save-status');  grab element in the auto-save-row called 'save-status'
     
-    const data = {
-        item: row.querySelector('textarea[name="item"]').value, //get rows item name 
-        description: row.querySelector('input[name="description"]').value, //get rows description option
-        cycle: row.querySelector('textarea[name="cycle"]').value //get rows cycle text
+    const calValEl  = row.querySelector('input[name="cycleCalendarValue"]');
+    const calUnitEl = row.querySelector('select[name="cycleCalendarUnit"]');
+    const hrsEl     = row.querySelector('input[name="cycleHours"]');
+    const parsedInt = (el) => {
+        if (!el || el.value === '' || el.value == null) return null;
+        const n = parseInt(el.value, 10);
+        return isNaN(n) ? null : n;
     };
+    const parsedFloat = (el) => {
+        if (!el || el.value === '' || el.value == null) return null;
+        const n = parseFloat(el.value);
+        return isNaN(n) ? null : n;
+    };
+
+    const data = {
+        item: row.querySelector('textarea[name="item"]').value, //get rows item name
+        description: row.querySelector('input[name="description"]').value, //get rows description option
+        cycleCalendarValue: parsedInt(calValEl),
+        cycleCalendarUnit:  calUnitEl ? (calUnitEl.value || null) : null,
+        cycleHours:         parsedFloat(hrsEl)
+    };
+
+    refreshCompleteButtonState(row);
 
     ['lastDone', 'dueDate'].forEach((field, index) => { //loops through lastDone and dueDate fields
         const container = row.querySelector(`td:nth-child(${index === 0 ? 5 : 6}) .input-with-dropdown`); //grab .input-with-dropdown in td child n
@@ -213,7 +232,7 @@ function deleteRow(icon) {
     }
     const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute('content');
     const csrfHeader = document.querySelector('meta[name="_csrf_header"]').getAttribute('content');
-    showConfirm('Delete this entry?').then(confirmed => {
+    showConfirm('Delete this entry?', 'Delete').then(confirmed => {
         if (!confirmed) return;
         axios.delete(`/delete/${id}`, { headers: { [csrfHeader]: csrfToken } })
             .then(() => row.remove())
@@ -222,6 +241,126 @@ function deleteRow(icon) {
                 showToast('Could not delete the entry. Please try again.', 'error');
             });
     });
+}
+
+// Builds the human-readable cycle string from a row's structured inputs.
+// Used for the print-only column and the Excel export. Empty when no cycle.
+function formatCycleDisplay(row) {
+    const calVal  = row.querySelector('input[name="cycleCalendarValue"]')?.value;
+    const calUnit = row.querySelector('select[name="cycleCalendarUnit"]')?.value;
+    const hrs     = row.querySelector('input[name="cycleHours"]')?.value;
+    const parts = [];
+    if (calVal && parseInt(calVal, 10) > 0 && calUnit) {
+        parts.push(`${calVal} ${calUnit.toLowerCase()}`);
+    }
+    if (hrs && parseFloat(hrs) > 0) {
+        parts.push(`${hrs} hrs`);
+    }
+    return parts.join(' / ');
+}
+
+// Disable the Update button on rows where no structured cycle is set yet —
+// the server would reject the click anyway, so prevent the round-trip.
+function refreshCompleteButtonState(row) {
+    const btn = row.querySelector('.complete-btn');
+    if (!btn) return;
+    const calVal = row.querySelector('input[name="cycleCalendarValue"]')?.value;
+    const calUnit = row.querySelector('select[name="cycleCalendarUnit"]')?.value;
+    const hrs    = row.querySelector('input[name="cycleHours"]')?.value;
+    const hasCal = calVal && parseInt(calVal, 10) > 0 && calUnit;
+    const hasHrs = hrs    && parseFloat(hrs)         > 0;
+    if (hasCal || hasHrs) {
+        btn.removeAttribute('disabled');
+        btn.title = 'Mark maintenance complete: sets Last Done to today/current hours and rolls Due Date forward by the cycle.';
+    } else {
+        btn.setAttribute('disabled', 'disabled');
+        btn.title = 'Set a cycle (months/years/days or hours) on this row to enable.';
+    }
+}
+
+function refreshAllCompleteButtons() {
+    document.querySelectorAll('.auto-save-row').forEach(refreshCompleteButtonState);
+}
+
+// Click handler for the per-row "complete maintenance" button.
+// Server is authoritative for today + current hours; client only repaints
+// the row from the response so a stale tab can't desync the displayed value.
+async function completeMaintenance(button) {
+    const row = button.closest('.auto-save-row');
+    if (!row) return;
+    const id = row.getAttribute('data-id');
+    if (!id) {
+        showToast('Could not identify row.', 'error');
+        return;
+    }
+    const confirmed = await showConfirm(
+        'Mark this maintenance as just completed? This will reset Last Done to today / current hours and roll Due Date forward by the cycle.',
+        'Mark complete');
+    if (!confirmed) return;
+    try {
+        const csrfToken  = document.querySelector('meta[name="_csrf"]').getAttribute('content');
+        const csrfHeader = document.querySelector('meta[name="_csrf_header"]').getAttribute('content');
+        const response = await axios.post(`/completeMaintenance/${id}`, {}, {
+            headers: { [csrfHeader]: csrfToken, 'Content-Type': 'application/json' }
+        });
+        const { lastDone, dueDate, timeLeft } = response.data;
+        repaintDateHoursCell(row, 'lastDone', lastDone);
+        repaintDateHoursCell(row, 'dueDate',  dueDate);
+        row.setAttribute('data-lastDone', lastDone || '');
+        row.setAttribute('data-dueDate',  dueDate  || '');
+        const tl = row.querySelector('td:nth-child(7) .time-left');
+        if (tl) setTimeLeftText(tl, timeLeft || 'N/A');
+        showToast('Maintenance completed. Due Date rolled forward.', 'success');
+    } catch (error) {
+        const msg = error?.response?.data?.message || 'Failed to update maintenance.';
+        showToast(msg, 'error');
+    }
+}
+
+// Rebuilds the dual-input cell (date input and/or hours input) from a
+// "YYYY-MM-DD <hours>" string. Mirrors the loader at the bottom of dashboard.js
+// so manual edits keep working after the button fires.
+function repaintDateHoursCell(row, field, value) {
+    const tdIndex = field === 'lastDone' ? 5 : 6;
+    const container = row.querySelector(`td:nth-child(${tdIndex}) .input-with-dropdown`);
+    if (!container) return;
+    container.querySelectorAll('input.extra-input').forEach(i => i.remove());
+    container.querySelectorAll('.add-type').forEach(btn => btn.textContent = '+');
+    if (!value) return;
+
+    const parts = value.split(' ');
+    let datePart = null, textPart = null;
+    if (parts[0] && parts[0].match(/^\d{4}-\d{2}-\d{2}$/)) {
+        datePart = parts[0];
+        if (parts.length > 1) textPart = parts.slice(1).join(' ');
+    } else {
+        textPart = value;
+    }
+    const trigger = container.querySelector('.trigger-dropdown');
+
+    if (datePart) {
+        const dateInput = document.createElement('input');
+        dateInput.type = 'date';
+        dateInput.name = `${field}_date`;
+        dateInput.className = 'extra-input';
+        dateInput.value = datePart;
+        dateInput.oninput = () => autoSave(dateInput);
+        container.insertBefore(dateInput, trigger);
+        const calBtn = container.querySelector('.add-type[data-type="calendar"]');
+        if (calBtn) calBtn.textContent = '-';
+    }
+    if (textPart) {
+        const textInput = document.createElement('input');
+        textInput.type = 'text';
+        textInput.name = `${field}_text`;
+        textInput.className = 'extra-input';
+        textInput.placeholder = 'Enter hours';
+        textInput.value = textPart;
+        textInput.oninput = () => autoSave(textInput);
+        container.insertBefore(textInput, trigger);
+        const clkBtn = container.querySelector('.add-type[data-type="clock"]');
+        if (clkBtn) clkBtn.textContent = '-';
+    }
 }
 
 function updateOrderOnServer() {
@@ -280,35 +419,50 @@ function selectOption(option) {
     if (dropdown.closest('.auto-save-row')) autoSave(hiddenInput);
 }
 
-function addCustomDescription(button) {
+async function addCustomDescription(button) {
     const container = button.parentElement;
     const input = container.querySelector('.custom-description');
     const customValue = input.value.trim();
     if (!customValue) return;
-    // Add the new option to all dropdowns without selecting it
-    if (!isDefaultOption(customValue)) {
-        updateAllDropdowns(customValue);
+    if (isDefaultOption(customValue)) { input.value = ''; return; }
+    // Already present in any dropdown? Just clear and bail — no double-add.
+    if (document.querySelector(`.dropdown-options .option[data-value="${CSS.escape(customValue)}"]`)) {
+        input.value = '';
+        return;
     }
-    input.value = '';
-    // Do not select the new option or trigger autoSave
+    try {
+        const csrfToken  = document.querySelector('meta[name="_csrf"]').getAttribute('content');
+        const csrfHeader = document.querySelector('meta[name="_csrf_header"]').getAttribute('content');
+        const response = await axios.post('/addDescriptionOption',
+            { option: customValue },
+            { headers: { [csrfHeader]: csrfToken, 'Content-Type': 'application/json' } });
+        const { id, option } = response.data;
+        updateAllDropdowns(option, id);
+        input.value = '';
+    } catch (error) {
+        const msg = error?.response?.data?.message || 'Failed to add option';
+        showToast(msg, 'error');
+    }
 }
 
-function updateAllDropdowns(newOption) {
+function updateAllDropdowns(newOption, optionId) {
     document.querySelectorAll('.dropdown-options').forEach(dropdown => {
-        if (!dropdown.querySelector(`.option[data-value="${newOption}"]`)) {
+        if (!dropdown.querySelector(`.option[data-value="${CSS.escape(newOption)}"]`)) {
             const optionDiv = document.createElement('div');
             optionDiv.className = 'option custom-option';
             optionDiv.setAttribute('data-value', newOption);
-            // Create span for the option text
+            if (optionId != null) optionDiv.setAttribute('data-option-id', optionId);
             const span = document.createElement('span');
             span.textContent = newOption;
             optionDiv.appendChild(span);
-            // Create remove button
             const removeBtn = document.createElement('button');
             removeBtn.className = 'remove-option-btn';
             removeBtn.textContent = 'x';
-            // Use data-option-value since we don't have an ID yet
-            removeBtn.setAttribute('data-option-value', newOption);
+            if (optionId != null) {
+                removeBtn.setAttribute('data-option-id', optionId);
+            } else {
+                removeBtn.setAttribute('data-option-value', newOption);
+            }
             optionDiv.appendChild(removeBtn);
             optionDiv.onclick = () => selectOption(optionDiv);
             dropdown.insertBefore(optionDiv, dropdown.querySelector('.add-option-container'));
@@ -486,15 +640,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
     document.addEventListener('click', function(event) {
-        if (event.target.className === 'remove-option-btn') {
+        const removeBtn = event.target.closest('.remove-option-btn');
+        if (removeBtn) {
             event.preventDefault();
             event.stopPropagation();
-            const optionId = event.target.getAttribute('data-option-id');
-            const optionValue = event.target.getAttribute('data-option-value');
-            const optionDiv = event.target.closest('.option');
+            const optionId = removeBtn.getAttribute('data-option-id');
+            const optionValue = removeBtn.getAttribute('data-option-value');
+            const optionDiv = removeBtn.closest('.option');
             const deletedValue = optionDiv.getAttribute('data-value');
     
-            showConfirm('Delete this option?').then(confirmed => {
+            showConfirm('Delete this option?', 'Delete').then(confirmed => {
                 if (!confirmed) return;
                 if (optionId) {
                     // Existing option with an ID (from server)
@@ -634,8 +789,8 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     
     function selectOption(option) {
-        if (event.target.classList.contains('remove-option-btn')) {
-            return; // Prevent selection on remove button click
+        if (event.target.closest('.remove-option-btn')) {
+            return; // Prevent selection on remove button click (icon or text)
         }
         const dropdown = option.closest('.custom-dropdown');
         const selected = dropdown.querySelector('.selected-option');
@@ -657,15 +812,8 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    document.querySelectorAll('.auto-save-row textarea[name="cycle"]').forEach(textarea => {
-        setTextareaMinHeight(textarea);
-        textarea.addEventListener('input', () => {
-            setTextareaMinHeight(textarea);
-        });
-    });
-
     window.addEventListener('resize', () => {
-        document.querySelectorAll('.auto-save-row textarea[name="item"], .auto-save-row textarea[name="cycle"], .add-row textarea[name="item"], .add-row textarea[name="cycle"]').forEach(textarea => {
+        document.querySelectorAll('.auto-save-row textarea[name="item"], .add-row textarea[name="item"]').forEach(textarea => {
             setTextareaMinHeight(textarea);
         });
     });
@@ -690,7 +838,24 @@ document.addEventListener('DOMContentLoaded', () => {
         const titleRow = titleCell.closest('tr');
         filterByTitle(titleRow);
     });
-    
+
+    // Mobile/narrow: tap an item card's headline to collapse it down to just the
+    // item name; tap again (or tap the collapsed card) to expand. Cards are
+    // expanded by default. Delegated on .sortable so dynamically-added rows work
+    // too. The 960px gate matches the CSS card breakpoint, so toggling works for
+    // the whole card range and stays disabled on the desktop table (>=961px).
+    document.querySelector('.sortable').addEventListener('click', function(e) {
+        if (!window.matchMedia('(max-width: 960px)').matches) return;
+        const itemCell = e.target.closest('td[data-label="Item"]');
+        if (!itemCell) return;
+        const row = itemCell.closest('tr');
+        if (!row || row.classList.contains('title-row') || row.classList.contains('add-row')) return;
+        // While expanded, a tap inside the name textarea edits it (don't toggle).
+        // While collapsed, a tap anywhere on the card re-expands it.
+        if (e.target.closest('textarea') && !row.classList.contains('collapsed')) return;
+        row.classList.toggle('collapsed');
+    });
+
     let currentSectionId = null; // To track the current section being viewed
     function filterByTitle(titleRow) {
         currentSectionId = titleRow.getAttribute('data-id');
@@ -875,21 +1040,14 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     updateAllTimeLeft();
-    
+    refreshAllCompleteButtons();
+
     function closeTypeDropdowns(event) {
         if (!event.target.closest('.input-with-dropdown')) {
             document.querySelectorAll('.type-dropdown').forEach(dropdown => {
                 dropdown.style.display = 'none';
             });
         }
-    }
-
-    const addRowCycleTextarea = document.querySelector('.add-row textarea[name="cycle"]');
-    if (addRowCycleTextarea) {
-        setTextareaMinHeight(addRowCycleTextarea);
-        addRowCycleTextarea.addEventListener('input', () => {
-            setTextareaMinHeight(addRowCycleTextarea);
-        });
     }
 
     const addRowItemTextarea = document.querySelector('.add-row textarea[name="item"]');
@@ -948,10 +1106,12 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         const description = document.querySelector('.add-row .custom-dropdown input[name="description"]').value;
-        const cycle = document.querySelector('.add-row textarea[name="cycle"]').value;
         const lastDone = document.getElementById('lastDoneHidden').value;
         const dueDate = document.getElementById('dueDateHidden').value;
         const timeLeft = document.querySelector('.add-row .time-left').textContent;
+        const addCalVal  = document.querySelector('.add-row input[name="cycleCalendarValue"]')?.value || '';
+        const addCalUnit = document.querySelector('.add-row select[name="cycleCalendarUnit"]')?.value || '';
+        const addHrs     = document.querySelector('.add-row input[name="cycleHours"]')?.value || '';
 
         const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute('content');
         const csrfHeader = document.querySelector('meta[name="_csrf_header"]').getAttribute('content');
@@ -960,7 +1120,9 @@ document.addEventListener('DOMContentLoaded', () => {
             item: item,
             isTitle: isTitleHidden.value,
             description: description,
-            cycle: cycle,
+            cycleCalendarValue: addCalVal,
+            cycleCalendarUnit: addCalUnit,
+            cycleHours: addHrs,
             lastDone: lastDone,
             dueDate: dueDate,
             timeLeft: timeLeft,
@@ -983,6 +1145,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 newRow.innerHTML = `
                     <td class="grip-cell"><span class="grip-icon no-print"><i class="fa-solid fa-grip-vertical"></i></span></td>
                     <td colspan="6" class="title-cell">${newRowData.item}</td>
+                    <td class="complete-cell no-print"></td>
                     <td class="delete-cell"><span class="delete-icon no-print" onclick="deleteRow(this)"><i class="fa-solid fa-trash-can fa-xl"></i></span></td>
                 `;
             } else {
@@ -992,8 +1155,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 newRow.setAttribute('data-cycle', newRowData.cycle);
                 newRow.innerHTML = `
                 <td class="grip-cell"><span class="grip-icon no-print"><i class="fa-solid fa-grip-vertical"></i></span></td>
-                <td><textarea name="item" class="no-print" oninput="autoSave(this)">${newRowData.item}</textarea><span class="print-only">${newRowData.item}</span></td>
-                <td>
+                <td data-label="Item"><textarea name="item" class="no-print" oninput="autoSave(this)">${newRowData.item}</textarea><i class="fa-solid fa-chevron-down card-caret no-print"></i><span class="print-only">${newRowData.item}</span></td>
+                <td data-label="Description">
                     <div class="custom-dropdown no-print">
                         <div class="selected-option no-print">${newRowData.description}</div>
                         <input type="hidden" name="description" value="${newRowData.description}">
@@ -1012,8 +1175,26 @@ document.addEventListener('DOMContentLoaded', () => {
                     </div>
                     <span class="print-only">${newRowData.description}</span>
                 </td>
-                <td><textarea name="cycle" class="no-print" oninput="autoSave(this)">${newRowData.cycle}</textarea><span class="print-only">${newRowData.cycle}</span></td>
-                <td>
+                <td data-label="Cycle">
+                    <div class="cycle-structured no-print">
+                        <div class="cycle-row">
+                            <input type="number" min="1" step="1" name="cycleCalendarValue" class="cycle-num" placeholder="#"
+                                value="${newRowData.cycleCalendarValue ?? ''}" oninput="autoSave(this)">
+                            <select name="cycleCalendarUnit" class="cycle-unit" onchange="autoSave(this)">
+                                <option value="" ${!newRowData.cycleCalendarUnit ? 'selected' : ''}>unit</option>
+                                <option value="DAYS"   ${newRowData.cycleCalendarUnit === 'DAYS'   ? 'selected' : ''}>days</option>
+                                <option value="MONTHS" ${newRowData.cycleCalendarUnit === 'MONTHS' ? 'selected' : ''}>months</option>
+                                <option value="YEARS"  ${newRowData.cycleCalendarUnit === 'YEARS'  ? 'selected' : ''}>years</option>
+                            </select>
+                        </div>
+                        <div class="cycle-row">
+                            <input type="number" min="0.1" step="0.1" name="cycleHours" class="cycle-num" placeholder="#"
+                                value="${newRowData.cycleHours ?? ''}" oninput="autoSave(this)">
+                            <span class="cycle-unit-label">hrs</span>
+                        </div>
+                    </div>
+                </td>
+                <td data-label="Last Done">
                     <div class="input-with-dropdown no-print">
                         <i class="fa-solid fa-chevron-down trigger-dropdown"></i>
                         <div class="type-dropdown" style="display: none;">
@@ -1023,7 +1204,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     </div>
                     <span class="print-only">${newRowData.lastDone}</span>
                 </td>
-                <td>
+                <td data-label="Due Date">
                     <div class="input-with-dropdown no-print">
                         <i class="fa-solid fa-chevron-down trigger-dropdown"></i>
                         <div class="type-dropdown" style="display: none;">
@@ -1033,8 +1214,16 @@ document.addEventListener('DOMContentLoaded', () => {
                     </div>
                     <span class="print-only">${newRowData.dueDate}</span>
                 </td>
-                <td><div class="time-left">${newRowData.timeLeft}</div></td>
-                <td class="delete-cell"><span class="delete-icon no-print" onclick="deleteRow(this)"><i class="fa-solid fa-trash-can fa-xl"></i></span></td>
+                <td data-label="Time Left"><div class="time-left">${newRowData.timeLeft ?? ''}</div></td>
+                <td class="complete-cell no-print" data-label="">
+                    <button type="button" class="complete-btn"
+                            title="Mark maintenance complete"
+                            onclick="completeMaintenance(this)">
+                        <i class="fa-solid fa-rotate-right"></i>
+                        <span class="complete-btn-label">Mark complete</span>
+                    </button>
+                </td>
+                <td class="delete-cell" data-label=""><span class="delete-icon no-print" onclick="deleteRow(this)"><i class="fa-solid fa-trash-can fa-xl"></i></span></td>
             `;
                     // Handle lastDone and dueDate inputs (existing code)
                     ['lastDone', 'dueDate'].forEach((field, index) => {
@@ -1107,13 +1296,9 @@ document.addEventListener('DOMContentLoaded', () => {
                             setTextareaMinHeight(itemTextarea);
                         });
                     }
-                    const cycleTextarea = newRow.querySelector('textarea[name="cycle"]');
-                    if (cycleTextarea) {
-                        setTextareaMinHeight(cycleTextarea);
-                        cycleTextarea.addEventListener('input', () => {
-                            setTextareaMinHeight(cycleTextarea);
-                        });
-                    }
+                    // New rows aren't covered by the page-load refreshAllCompleteButtons
+                    // pass, so initialize the Update-button state here.
+                    refreshCompleteButtonState(newRow);
                 }
 
                 // Update the order on the server TAKE A LOOK HERE
@@ -1123,7 +1308,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Reset add row (existing code)
                 document.querySelector('.add-row textarea[name="item"]').value = '';
                 document.querySelector('.add-row input[name="title"]').value = '';
-                document.querySelector('.add-row textarea[name="cycle"]').value = '';
+                const addCalValEl  = document.querySelector('.add-row input[name="cycleCalendarValue"]');
+                const addCalUnitEl = document.querySelector('.add-row select[name="cycleCalendarUnit"]');
+                const addHrsEl     = document.querySelector('.add-row input[name="cycleHours"]');
+                if (addCalValEl)  addCalValEl.value  = '';
+                if (addCalUnitEl) addCalUnitEl.value = '';
+                if (addHrsEl)     addHrsEl.value     = '';
                 document.querySelector('.add-row .custom-dropdown input[name="description"]').value = '';
                 document.querySelector('.add-row .selected-option').textContent = '';
                 document.querySelectorAll('.add-row .input-with-dropdown input.extra-input').forEach(input => input.remove());
@@ -1264,7 +1454,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Data row: Extract values (similar to autoSave)
                 const item = row.querySelector('textarea[name="item"]')?.value || '';
                 const desc = row.querySelector('input[name="description"]')?.value || '';
-                const cycle = row.querySelector('textarea[name="cycle"]')?.value || '';
+                const cycle = formatCycleDisplay(row);
                 let lastDone = '';
                 let dueDate = '';
 
@@ -1343,10 +1533,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const descPrint = row.querySelector('td:nth-child(3) .print-only');
             if (descInput && descPrint) descPrint.textContent = descInput.value;
 
-            // Cycle
-            const cycleTextarea = row.querySelector('textarea[name="cycle"]');
+            // Cycle (from structured fields)
             const cyclePrint = row.querySelector('td:nth-child(4) .print-only');
-            if (cycleTextarea && cyclePrint) cyclePrint.textContent = cycleTextarea.value;
+            if (cyclePrint) cyclePrint.textContent = formatCycleDisplay(row);
 
             // Last Done (construct from inputs)
             const lastDoneContainer = row.querySelector('td:nth-child(5) .input-with-dropdown');
@@ -1389,18 +1578,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // NEW: Add log row via AJAX
     document.getElementById('add-log-button').addEventListener('click', async () => {  // Note: made async for await if needed
-        const hobbsIn = parseFloat(document.getElementById('hobbsIn').value) || 0;
-        const hobbsOut = parseFloat(document.getElementById('hobbsOut').value) || 0;
-        const tachIn = parseFloat(document.getElementById('tachIn').value) || 0;
-        const tachOut = parseFloat(document.getElementById('tachOut').value) || 0;
-    
+        // Read raw strings first so an empty input stays null (not 0), letting
+        // the server enforce the "complete pair" rule cleanly.
+        const rawHobbsIn  = document.getElementById('hobbsIn').value.trim();
+        const rawHobbsOut = document.getElementById('hobbsOut').value.trim();
+        const rawTachIn   = document.getElementById('tachIn').value.trim();
+        const rawTachOut  = document.getElementById('tachOut').value.trim();
+        const numOrNull = (s) => (s === '' || isNaN(parseFloat(s))) ? null : parseFloat(s);
+
         const data = {
             fromAirport: document.getElementById('fromAirport').value,
             toAirport: document.getElementById('toAirport').value,
-            hobbsIn: hobbsIn || null,
-            hobbsOut: hobbsOut || null,
-            tachIn: tachIn || null,
-            tachOut: tachOut || null
+            hobbsIn:  numOrNull(rawHobbsIn),
+            hobbsOut: numOrNull(rawHobbsOut),
+            tachIn:   numOrNull(rawTachIn),
+            tachOut:  numOrNull(rawTachOut)
         };
     
         const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute('content');
@@ -1489,9 +1681,19 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('tachIn').value = '';
         document.getElementById('tachOut').value = '';
         } catch (error) {
-            console.error('Error adding log:', error);
+            // 400 = validation error from the server (e.g. partial pair, negative duration).
+            // Keep the user's typed values intact so they can correct and retry —
+            // the whole point of this code path is "don't hurt the user."
+            const serverMsg = error?.response?.data?.message;
+            const status    = error?.response?.status;
+            if (status === 400 && serverMsg) {
+                showToast(serverMsg, 'error');
+            } else {
+                console.error('Error adding log:', error);
+                showToast('Failed to add flight log.', 'error');
+            }
         }
-    }) 
+    })
 
 });
 

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -108,6 +108,7 @@
                         <th class = "print">Due Date</th>
                         <th class = "print">Time Left</th>
                         <!--<th class = "status-header">Status</th>-->
+                        <th class = "complete-header no-print"></th>
                         <th class = "delete-header"></th>
                     </tr>
                 </thead>
@@ -121,14 +122,15 @@
                         <tr th:if="${timeline.isTitle}" class="title-row" th:data-id="${timeline.id}">
                             <td class = "grip-cell"><span class="grip-icon no-print"><i class="fa-solid fa-grip-vertical"></i></span></td>
                             <td colspan="6" class="title-cell" th:text="${timeline.item}"></td>
+                            <td class="complete-cell no-print"></td>
                             <td class="delete-cell"><span class="delete-icon no-print" onclick="deleteRow(this)"><i class="fa-solid fa-trash-can fa-xl"></i></span></td>
                         </tr>
                         <!-- Regular item row -->
                         <tr th:unless="${timeline.isTitle}" th:data-id="${timeline.id}" th:data-lastDone="${timeline.lastDone}" th:data-dueDate="${timeline.dueDate}" th:data-cycle="${timeline.cycle}" class="auto-save-row">                           
                             <td class = "grip-cell"><span class="grip-icon no-print"><i class="fa-solid fa-grip-vertical"></i></span></td>
-                            <td><textarea name="item" th:text="${timeline.item}" oninput="autoSave(this)" class="no-print"></textarea>
+                            <td data-label="Item"><textarea name="item" rows="1" th:text="${timeline.item}" oninput="autoSave(this)" class="no-print"></textarea><i class="fa-solid fa-chevron-down card-caret no-print"></i>
                                 <span class="print-only" th:text="${timeline.item}"></span></td>
-                            <td>
+                            <td data-label="Description">
                                 <div class="custom-dropdown no-print">
                                     <div class="selected-option no-print"></div>
                                     <input type="hidden" name="description" th:value="${timeline.description}">
@@ -141,7 +143,7 @@
                                         <div class="option" data-value="Overhaul">Overhaul</div>
                                         <div th:each="option : ${descriptionOptions}" class="option custom-option" th:data-value="${option.option}" th:data-option-id="${option.id}">
                                             <span th:text="${option.option}"></span>
-                                            <button class="remove-option-btn" th:data-option-id="${option.id}"><i class="fa-solid fa-xmark"></i></button>
+                                            <button class="remove-option-btn" th:data-option-id="${option.id}">x</button>
                                         </div>
                                         <div class="add-option-container">
                                             <input type="text" class="custom-description" placeholder="New option">
@@ -151,8 +153,31 @@
                                 </div>
                                 <span class="print-only" th:text="${timeline.description}"></span>
                             </td>
-                            <td><textarea name="cycle" oninput="autoSave(this)" th:text="${timeline.cycle}" class="no-print"></textarea><span class="print-only" th:text="${timeline.cycle}"></span></td>
-                            <td>
+                            <td data-label="Cycle">
+                                <div class="cycle-structured no-print">
+                                    <div class="cycle-row">
+                                        <input type="number" min="1" step="1" name="cycleCalendarValue"
+                                            class="cycle-num" placeholder="#"
+                                            th:value="${timeline.cycleCalendarValue}"
+                                            oninput="autoSave(this)">
+                                        <select name="cycleCalendarUnit" class="cycle-unit" onchange="autoSave(this)">
+                                            <option value="" th:selected="${timeline.cycleCalendarUnit == null}">unit</option>
+                                            <option value="DAYS"   th:selected="${timeline.cycleCalendarUnit == 'DAYS'}">days</option>
+                                            <option value="MONTHS" th:selected="${timeline.cycleCalendarUnit == 'MONTHS'}">months</option>
+                                            <option value="YEARS"  th:selected="${timeline.cycleCalendarUnit == 'YEARS'}">years</option>
+                                        </select>
+                                    </div>
+                                    <div class="cycle-row">
+                                        <input type="number" min="0.1" step="0.1" name="cycleHours"
+                                            class="cycle-num" placeholder="#"
+                                            th:value="${timeline.cycleHours}"
+                                            oninput="autoSave(this)">
+                                        <span class="cycle-unit-label">hrs</span>
+                                    </div>
+                                </div>
+                                <span class="print-only"></span>
+                            </td>
+                            <td data-label="Last Done">
                                 <div class="input-with-dropdown no-print">
                                     <i class="fa-solid fa-chevron-down trigger-dropdown"></i>
                                     <div class="type-dropdown" style="display: none;">
@@ -168,7 +193,7 @@
                                 </div>
                                 <span class="print-only" th:text="${timeline.lastDone}"></span>
                             </td>
-                            <td>
+                            <td data-label="Due Date">
                                 <div class="input-with-dropdown no-print">
                                     <i class="fa-solid fa-chevron-down trigger-dropdown"></i>
                                     <div class="type-dropdown" style="display: none;">
@@ -184,9 +209,17 @@
                                 </div>
                                 <span class="print-only" th:text="${timeline.dueDate}"></span>
                             </td>
-                            <td><div class="time-left" th:text="${timeline.timeLeft != null ? timeline.timeLeft : ''}"></div></td>
+                            <td data-label="Time Left"><div class="time-left" th:text="${timeline.timeLeft != null ? timeline.timeLeft : ''}"></div></td>
                             <!--<td class="status-cell"><span class="save-status no-print">✓</span></td>-->
-                            <td class="delete-cell"><span class="delete-icon no-print" onclick="deleteRow(this)"><i class="fa-solid fa-trash-can fa-xl"></i></span></td>
+                            <td class="complete-cell no-print" data-label="">
+                                <button type="button" class="complete-btn"
+                                        title="Mark maintenance complete: sets Last Done to today/current hours and rolls Due Date forward by the cycle."
+                                        onclick="completeMaintenance(this)">
+                                    <i class="fa-solid fa-rotate-right"></i>
+                                    <span class="complete-btn-label">Mark complete</span>
+                                </button>
+                            </td>
+                            <td class="delete-cell" data-label=""><span class="delete-icon no-print" onclick="deleteRow(this)"><i class="fa-solid fa-trash-can fa-xl"></i></span></td>
                         </tr>
                     </th:block>
                 </tbody>
@@ -194,13 +227,13 @@
                 <tbody>
                     <tr class="add-row no-print"> <!-- Add row -->
                         <td class="grip-column"></td>
-                        <td>
+                        <td data-label="Item">
                             <div class="row-type-selector"> <!--Choose Item/Title-->
                                 <span class="row-type-option" data-type="item" onclick="selectRowType('item', this)">Item</span> <!-- Item button -->
                                 <span class="row-type-option" data-type="title" onclick="selectRowType('title', this)">Title</span> <!-- Title button -->
                             </div>
                             <div id="itemInput" style="display: none;"> <!--"Enter Item" item textarea div-->
-                                <textarea name="item" placeholder="Enter item"></textarea> <!--Item textarea-->
+                                <textarea name="item" rows="1" placeholder="Enter item"></textarea> <!--Item textarea-->
                             </div>
                             <div id="titleInput" style="display: none;"> <!--"Enter Title" title -->
                                 <input type="text" name="title" placeholder="Enter title" class="title-input">
@@ -208,7 +241,7 @@
                             <input type="hidden" name="item" id="itemHidden">
                             <input type="hidden" name="isTitle" id="isTitleHidden" value="false">
                         </td>
-                        <td>
+                        <td data-label="Description">
                             <div class="custom-dropdown no-print">
                                 <div class="selected-option no-print"></div>
                                 <input type="hidden" name="description" value="">
@@ -230,8 +263,24 @@
                                 </div>
                             </div>
                         </td>
-                        <td><textarea placeholder = "Service cycle time. Ex. 100 hours" name="cycle"></textarea></td>
-                        <td>
+                        <td data-label="Cycle">
+                            <div class="cycle-structured">
+                                <div class="cycle-row">
+                                    <input type="number" min="1" step="1" name="cycleCalendarValue" class="cycle-num" placeholder="#">
+                                    <select name="cycleCalendarUnit" class="cycle-unit">
+                                        <option value="" selected>unit</option>
+                                        <option value="DAYS">days</option>
+                                        <option value="MONTHS">months</option>
+                                        <option value="YEARS">years</option>
+                                    </select>
+                                </div>
+                                <div class="cycle-row">
+                                    <input type="number" min="0.1" step="0.1" name="cycleHours" class="cycle-num" placeholder="#">
+                                    <span class="cycle-unit-label">hrs</span>
+                                </div>
+                            </div>
+                        </td>
+                        <td data-label="Last Done">
                             <div class="input-with-dropdown">
                                 <i class="fa-solid fa-chevron-down trigger-dropdown"></i>
                                 <div class="type-dropdown" style="display: none;">
@@ -241,7 +290,7 @@
                             </div>
                             <input type="hidden" name="lastDone" id="lastDoneHidden">
                         </td>
-                        <td>
+                        <td data-label="Due Date">
                             <div class="input-with-dropdown">
                                 <i class="fa-solid fa-chevron-down trigger-dropdown"></i>
                                 <div class="type-dropdown" style="display: none;">
@@ -251,9 +300,12 @@
                             </div>
                             <input type="hidden" name="dueDate" id="dueDateHidden">
                         </td>
-                        <td><div class="time-left"></div></td>
+                        <td data-label="Time Left"><div class="time-left"></div></td>
                         <!--<td class="status-cell"><span class="save-status"></span></td>-->
-                        <td class="add-cell">
+                        <!-- add-cell spans 2 columns so the Add button gets room
+                             to breathe AND grows with screen width (those two
+                             columns are 4%+4% of viewport). -->
+                        <td class="add-cell no-print" data-label="" colspan="2">
                             <form method="post" th:action="@{/dashboard}">
                                 <input type="hidden" name="item" id="itemHiddenDuplicate">
                                 <input type="hidden" name="isTitle" id="isTitleHiddenDuplicate" value="false">

--- a/src/test/java/com/example/AviaryService/controllers/UserControllerTest.java
+++ b/src/test/java/com/example/AviaryService/controllers/UserControllerTest.java
@@ -1,9 +1,11 @@
 package com.example.AviaryService.controllers;
 
 import com.example.AviaryService.entity.DescriptionOption;
+import com.example.AviaryService.entity.FlightLog;
 import com.example.AviaryService.entity.ServiceTimeline;
 import com.example.AviaryService.entity.User;
 import com.example.AviaryService.repositories.DescriptionOptionRepository;
+import com.example.AviaryService.repositories.FlightLogRepository;
 import com.example.AviaryService.repositories.ServiceTimelineRepository;
 import com.example.AviaryService.repositories.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +24,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -45,6 +49,9 @@ class UserControllerTest {
     private DescriptionOptionRepository descriptionOptionRepository;
 
     @Autowired
+    private FlightLogRepository flightLogRepository;
+
+    @Autowired
     private PasswordEncoder passwordEncoder;
 
     @BeforeEach
@@ -52,6 +59,7 @@ class UserControllerTest {
         // Clear existing data to avoid duplicates and foreign key violations
         descriptionOptionRepository.deleteAll();
         serviceTimelineRepository.deleteAll();
+        flightLogRepository.deleteAll();
         userRepository.deleteAll();
 
         // Create 50 users with 2 timelines each
@@ -147,5 +155,95 @@ class UserControllerTest {
         User user = userRepository.findByUsername("user2");
         assertTrue("flightlog".equals(user.getTachUpdatedSource()), "tach source should be 'flightlog'");
         assertTrue(user.getTachUpdatedAt() != null, "tachUpdatedAt should be set after a flight log");
+    }
+
+    // ── Regression tests for the meter-snapshot rewrite ───────────────────────
+    // These pin down the three bugs from the original /addflightlog logic:
+    //   1. Partial entry (e.g. only tachOut) used to wipe BOTH meters to 0.
+    //   2. Manual edits used to be silently overwritten by log activity.
+    //   3. Deleting a log used to set hours to 0 instead of reverting.
+
+    @Test
+    @WithMockUser(username = "user3", roles = {"USER"})
+    void testAddFlightLogRejectsPartialPairAndPreservesHours() throws Exception {
+        // Set up a user with manually-entered hours.
+        User u = userRepository.findByUsername("user3");
+        u.setHobbsHours(100.0);
+        u.setHobbsManualBaseline(100.0);
+        u.setTachHours(100.0);
+        u.setTachManualBaseline(100.0);
+        userRepository.save(u);
+
+        // The original bug: posting a log with only tachOut filled in.
+        mockMvc.perform(post("/addflightlog")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"fromAirport\":\"KAAA\",\"toAirport\":\"KBBB\",\"tachOut\":500.0}")
+                .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().isBadRequest());
+
+        // Critical: the meters must NOT have been touched.
+        User after = userRepository.findByUsername("user3");
+        assertEquals(100.0, after.getHobbsHours(), 0.0001, "Hobbs hours must not be wiped by a rejected partial entry");
+        assertEquals(100.0, after.getTachHours(), 0.0001, "Tach hours must not be wiped by a rejected partial entry");
+        assertTrue(flightLogRepository.findByUser(after).isEmpty(), "No partial log should have been saved");
+    }
+
+    @Test
+    @WithMockUser(username = "user4", roles = {"USER"})
+    void testManualBaselineActsAsFloorAgainstLowerLogReadings() throws Exception {
+        // User manually claims 200 hours on the airframe.
+        User u = userRepository.findByUsername("user4");
+        u.setHobbsHours(200.0);
+        u.setHobbsManualBaseline(200.0);
+        u.setTachHours(200.0);
+        u.setTachManualBaseline(200.0);
+        userRepository.save(u);
+
+        // Add a complete log whose hobbsIn=50 is well BELOW the manual floor.
+        mockMvc.perform(post("/addflightlog")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"hobbsOut\":49.5,\"hobbsIn\":50.0,\"tachOut\":49.5,\"tachIn\":50.0}")
+                .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().isOk());
+
+        User after = userRepository.findByUsername("user4");
+        assertEquals(200.0, after.getHobbsHours(), 0.0001, "Manual baseline must not be overwritten by a lower log reading");
+        assertEquals(200.0, after.getTachHours(), 0.0001, "Manual baseline must not be overwritten by a lower log reading");
+    }
+
+    @Test
+    @WithMockUser(username = "user5", roles = {"USER"})
+    void testDeleteFlightLogRevertsToBaseline() throws Exception {
+        // Start at a manual baseline of 100.
+        User u = userRepository.findByUsername("user5");
+        u.setHobbsHours(100.0);
+        u.setHobbsManualBaseline(100.0);
+        u.setTachHours(100.0);
+        u.setTachManualBaseline(100.0);
+        userRepository.save(u);
+
+        // Add a log that raises hobbs to 150 and tach to 145.
+        mockMvc.perform(post("/addflightlog")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"hobbsOut\":100.0,\"hobbsIn\":150.0,\"tachOut\":100.0,\"tachIn\":145.0}")
+                .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().isOk());
+
+        User afterAdd = userRepository.findByUsername("user5");
+        assertEquals(150.0, afterAdd.getHobbsHours(), 0.0001, "Hobbs should be raised by the log");
+        assertEquals(145.0, afterAdd.getTachHours(), 0.0001, "Tach should be raised by the log");
+
+        // Delete that log — meters must revert to the baseline, not crash to 0.
+        List<FlightLog> logs = flightLogRepository.findByUser(afterAdd);
+        assertEquals(1, logs.size());
+        Long logId = logs.get(0).getId();
+
+        mockMvc.perform(delete("/deleteflightlog/" + logId)
+                .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().isOk());
+
+        User afterDelete = userRepository.findByUsername("user5");
+        assertEquals(100.0, afterDelete.getHobbsHours(), 0.0001, "Delete must revert Hobbs to the manual baseline");
+        assertEquals(100.0, afterDelete.getTachHours(), 0.0001, "Delete must revert Tach to the manual baseline");
     }
 }


### PR DESCRIPTION
Mobile (≤960px) service timeline reworked as cards:
- 1/2-2/1 layout (Item header; Description|Last Done; Cycle|Due Date; Time Left full-width centered) with separating gridlines, matching the add row; flat borderless fields like desktop
- tap item headline to collapse/expand (big FA chevron, works across the whole card range, disabled on desktop)
- add-row Title mode hides item-only fields; item name centered
- cycle unit dropdown uses the same FA chevron as the other fields, no longer overlaps Time Left
- raise card breakpoint to 960px so the timeline never overflows the page

Adds src/browserTest Playwright suite covering the above.